### PR TITLE
Update regen proto files 

### DIFF
--- a/packages/api/proto/regen/data/v1alpha2/events.proto
+++ b/packages/api/proto/regen/data/v1alpha2/events.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package regen.data.v1alpha2;
 
+import "regen/data/v1alpha2/types.proto";
+
 option go_package = "github.com/regen-network/regen-ledger/x/data";
 
 // EventAnchorData is an event emitted when data is anchored on-chain.

--- a/packages/api/proto/regen/data/v1alpha2/genesis.proto
+++ b/packages/api/proto/regen/data/v1alpha2/genesis.proto
@@ -23,4 +23,8 @@ message GenesisContentEntry {
 
     // signers are the signers, if any
     repeated SignerEntry signers = 3;
+
+    // content is the actual content if stored on-chain
+    Content content = 4;
+
 }

--- a/packages/api/proto/regen/data/v1alpha2/query.proto
+++ b/packages/api/proto/regen/data/v1alpha2/query.proto
@@ -12,29 +12,24 @@ option go_package = "github.com/regen-network/regen-ledger/x/data";
 // Query is the regen.data.v1alpha2 Query service
 service Query {
   // ByHash queries data based on its ContentHash.
-  rpc ByIRI (QueryByIRIRequest) returns (QueryByIRIResponse) {
-    option (google.api.http).get = "/regen/data/v1alpha2/by-iri/{iri}";
+  rpc ByHash (QueryByHashRequest) returns (QueryByHashResponse) {
+    option (google.api.http).get = "/regen/data/v1alpha2/by_hash";
   }
 
   // BySigner queries data based on signers.
   rpc BySigner (QueryBySignerRequest) returns (QueryBySignerResponse) {
-    option (google.api.http).get = "/regen/data/v1alpha2/by-signer/{signer}";
-  }
-
-  // Signers queries signers based on IRI.
-  rpc Signers(QuerySignersRequest) returns (QuerySignersResponse) {
-    option (google.api.http).get = "/regen/data/v1alpha2/signers/{iri}";
+    option (google.api.http).get = "/regen/data/v1alpha2/signers/{signer}";
   }
 }
 
 // QueryByContentHashRequest is the Query/ByContentHash request type.
-message QueryByIRIRequest {
+message QueryByHashRequest {
   // hash is the hash-based identifier for the anchored content.
-  string iri = 1;
+  ContentHash hash = 1;
 }
 
 // QueryByContentHashResponse is the Query/ByContentHash response type.
-message QueryByIRIResponse {
+message QueryByHashResponse {
   // entry is the ContentEntry
   ContentEntry entry = 1;
 }
@@ -67,24 +62,10 @@ message ContentEntry {
 
   // timestamp is the anchor Timestamp
   google.protobuf.Timestamp timestamp = 3;
-}
 
-// QuerySignersRequest is the Query/Signers request type.
-message QuerySignersRequest {
+  // signers are the signers, if any
+  repeated SignerEntry signers = 4;
 
-  // iri is the content IRI
-  string iri = 1;
-
-  // pagination is the PageRequest to use for pagination.
-  cosmos.base.query.v1beta1.PageRequest pagination = 2;
-}
-
-// QuerySignersResponse is the Query/QuerySigners response type.
-message QuerySignersResponse {
-
-  // signers are the addresses of the signers.
-  repeated string signers = 1;
-
-  // pagination is the pagination PageResponse.
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+  // content is the actual content if stored on-chain
+  Content content = 5;
 }

--- a/packages/api/proto/regen/data/v1alpha2/tx.proto
+++ b/packages/api/proto/regen/data/v1alpha2/tx.proto
@@ -39,6 +39,16 @@ service Msg {
   // SignData can be called multiple times for the same content hash with different
   // signers and those signers will be appended to the list of signers.
   rpc SignData(MsgSignData) returns (MsgSignDataResponse);
+
+  // StoreRawData stores a piece of raw data corresponding to an ContentHash.Raw on the blockchain.
+  //
+  // StoreRawData implicitly calls AnchorData if the data was not already anchored.
+  //
+  // The sender in StoreRawData is not attesting to the veracity of the underlying
+  // data. They can simply be a intermediary providing storage services.
+  // SignData should be used to create a digital signature attesting to the
+  // veracity of some piece of data.
+  rpc StoreRawData(MsgStoreRawData) returns (MsgStoreRawDataResponse);
 }
 
 // MsgAnchorData is the Msg/AnchorData request type.
@@ -54,11 +64,9 @@ message MsgAnchorData {
 
 // MsgAnchorData is the Msg/AnchorData response type.
 message MsgAnchorDataResponse {
+
   // timestamp is the timestamp of the block at which the data was anchored.
   google.protobuf.Timestamp timestamp = 1;
-
-  // iri is the IRI of the data that was anchored.
-  string iri = 2;
 }
 
 // MsgSignData is the Msg/SignData request type.
@@ -78,3 +86,20 @@ message MsgSignData {
 
 // MsgSignDataResponse is the Msg/SignData response type.
 message MsgSignDataResponse {}
+
+// MsgStoreRawData is the Msg/StoreRawData request type.
+message MsgStoreRawData {
+  // sender is the address of the sender of the transaction.
+  // The sender in StoreData is not attesting to the veracity of the underlying
+  // data. They can simply be a intermediary providing services.
+  string sender = 1;
+
+  // content_hash is the hash-based identifier for the anchored content.
+  ContentHash.Raw content_hash = 2;
+
+  // content is the content of the raw data corresponding to the provided content hash.
+  bytes content = 3;
+}
+
+// MsgStoreRawData is the Msg/StoreRawData response type.
+message MsgStoreRawDataResponse { }

--- a/packages/api/proto/regen/data/v1alpha2/types.proto
+++ b/packages/api/proto/regen/data/v1alpha2/types.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package regen.data.v1alpha2;
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 option go_package = "github.com/regen-network/regen-ledger/x/data";
 
@@ -142,6 +143,15 @@ enum DigestAlgorithm {
 
     // BLAKE2b-256
     DIGEST_ALGORITHM_BLAKE2B_256 = 1;
+}
+
+// Content is a wrapper for content stored on-chain
+message Content {
+    // sum selects the type of data
+    oneof sum {
+        // raw_data is the oneof field for raw data
+        bytes raw_data = 1;
+    }
 }
 
 // SignerEntry is a signer entry wrapping a signer address and timestamp

--- a/packages/api/proto/regen/ecocredit/basket/v1/events.proto
+++ b/packages/api/proto/regen/ecocredit/basket/v1/events.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package regen.ecocredit.basket.v1;
+
+import "regen/ecocredit/basket/v1/types.proto";
+
+option go_package = "github.com/regen-network/regen-ledger/x/ecocredit/basket";
+
+// EventCreate is an event emitted when a basket is created.
+message EventCreate {
+
+  // basket_denom is the basket bank denom.
+  string basket_denom = 1;
+
+  // curator is the address of the basket curator who is able to change certain
+  // basket settings.
+  string curator = 2;
+}
+
+// EventPut is an event emitted when credits are put into a basket in return
+// for basket tokens.
+message EventPut {
+
+  // owner is the owner of the credits put into the basket.
+  string owner = 1;
+
+  // basket_denom is the basket bank denom that the credits were added to.
+  string basket_denom = 2;
+
+  // credits are the credits that were added to the basket.
+  repeated BasketCredit credits = 3;
+
+  // amount is the integer number of basket tokens converted from credits.
+  string amount = 4;
+}
+
+// EventTake is an event emitted when credits are taken from a basket starting
+// from the oldest credits first.
+message EventTake {
+
+  // owner is the owner of the credits taken from the basket.
+  string owner = 1;
+
+  // basket_denom is the basket bank denom that credits were taken from.
+  string basket_denom = 2;
+
+  // credits are the credits that were taken from the basket.
+  repeated BasketCredit credits = 3;
+
+  // amount is the integer number of basket tokens converted to credits.
+  string amount = 4;
+}

--- a/packages/api/proto/regen/ecocredit/basket/v1/query.proto
+++ b/packages/api/proto/regen/ecocredit/basket/v1/query.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package regen.ecocredit.basket.v1;
+
+import "google/api/annotations.proto";
+import "regen/ecocredit/basket/v1/types.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+
+option go_package = "github.com/regen-network/regen-ledger/x/ecocredit/basket";
+
+// Msg is the regen.ecocredit.basket.v1beta1 Query service.
+service Query {
+
+    // Basket queries one basket by denom.
+    rpc Basket(QueryBasketRequest) returns (QueryBasketResponse) {
+        option (google.api.http).get =
+            "/regen/ecocredit/basket/v1/baskets/{basket_denom}";
+    }
+
+    // Baskets lists all baskets in the ecocredit module.
+    rpc Baskets(QueryBasketsRequest) returns (QueryBasketsResponse) {
+        option (google.api.http).get =
+            "/regen/ecocredit/basket/v1/baskets";
+    }
+
+    // BasketBalances lists the balance of each credit batch in the basket.
+    rpc BasketBalances(QueryBasketBalancesRequest) returns (QueryBasketBalancesResponse) {
+        option (google.api.http).get =
+            "/regen/ecocredit/basket/v1/baskets/{basket_denom}/balances";
+    }
+
+    // BasketBalance queries the balance of a specific credit batch in the basket.
+    rpc BasketBalance(QueryBasketBalanceRequest) returns (QueryBasketBalanceResponse) {
+        option (google.api.http).get =
+            "/regen/ecocredit/basket/v1/baskets/{basket_denom}/balances/{batch_denom}";
+    }
+}
+
+// QueryBasketRequest is the Query/Basket request type.
+message QueryBasketRequest {
+    // basket_denom represents the denom of the basket to query.
+    string basket_denom = 1;
+}
+
+// QueryBasketResponse is the Query/Basket response type.
+message QueryBasketResponse {
+    // basket is the queried basket.
+    Basket basket = 1;
+
+    // classes are the credit classes that can be deposited in the basket.
+    repeated string classes = 2;
+}
+
+// QueryBasketsRequest is the Query/Baskets request type.
+message QueryBasketsRequest {
+    // pagination defines an optional pagination for the request.
+    cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+// QueryBasketsResponse is the Query/Baskets response type.
+message QueryBasketsResponse {
+    // baskets are the fetched baskets.
+    repeated Basket baskets = 1;
+
+    // pagination defines the pagination in the response.
+    cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryBasketBalancesRequest is the Query/BasketBalances request type.
+message QueryBasketBalancesRequest {
+    // basket_denom is the denom of the basket.
+    string basket_denom = 1;
+
+    // pagination defines an optional pagination for the request.
+    cosmos.base.query.v1beta1.PageRequest pagination = 2;
+}
+
+// QueryBasketBalancesResponse is the Query/BasketBalances response type.
+message QueryBasketBalancesResponse {
+    // balances is a list of credit balances in the basket.
+    repeated BasketBalance balances = 1;
+
+    // pagination defines the pagination in the response.
+    cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryBasketBalanceRequest is the Query/BasketBalance request type.
+message QueryBasketBalanceRequest {
+    // basket_denom is the denom of the basket.
+    string basket_denom = 1;
+
+    // batch_denom is the denom of the credit batch.
+    string batch_denom = 2;
+}
+
+// QueryBasketBalanceResponse is the Query/BasketBalance response type.
+message QueryBasketBalanceResponse {
+    // balance is the amount of the queried credit batch in the basket.
+    string balance = 1;
+}

--- a/packages/api/proto/regen/ecocredit/basket/v1/tx.proto
+++ b/packages/api/proto/regen/ecocredit/basket/v1/tx.proto
@@ -1,0 +1,156 @@
+syntax = "proto3";
+
+package regen.ecocredit.basket.v1;
+
+option go_package = "github.com/regen-network/regen-ledger/x/ecocredit/basket";
+
+import "gogoproto/gogo.proto";
+import "regen/ecocredit/basket/v1/types.proto";
+import "cosmos/base/v1beta1/coin.proto";
+
+// Msg is the regen.ecocredit.basket.v1beta1 Msg service.
+service Msg {
+
+  // Create creates a bank denom which wraps credits.
+  rpc Create(MsgCreate) returns (MsgCreateResponse);
+
+  // Put puts credits into a basket in return for basket tokens.
+  rpc Put(MsgPut) returns (MsgPutResponse);
+
+  // Take takes credits from a basket starting from the oldest
+  // credits first.
+  rpc Take(MsgTake) returns (MsgTakeResponse);
+}
+
+// MsgCreate is the Msg/Create request type.
+message MsgCreate {
+  // curator is the address of the basket curator who is able to change certain
+  // basket settings.
+  string curator = 1;
+
+  // name will be used to together with prefix to create a bank denom for this
+  // basket token. It can be between 3-8 alphanumeric characters, with the
+  // first character being alphabetic.
+  //
+  // The bank denom will be formed from name, credit type and exponent and be
+  // of the form `eco.<prefix><credit_type_abbrev>.<name>` where prefix
+  // is derived from exponent.
+  string name = 2;
+
+  // description is a human-readable description of the basket denom that should
+  // be at most 256 characters.
+  string description = 3;
+
+  // exponent is the exponent that will be used for converting credits to basket
+  // tokens and for bank denom metadata. It also limits the precision of
+  // credit amounts when putting credits into a basket. An exponent of 6 will
+  // mean that 10^6 units of a basket token will be issued for 1.0 credits and that
+  // this should be displayed as one unit in user interfaces. It also means
+  // that the maximum precision of credit amounts is 6 decimal places so that
+  // the need to round is eliminated. The exponent must be >= the precision of
+  // the credit type at the time the basket is created and be of one of the
+  // following values 0, 1, 2, 3, 6, 9, 12, 15, 18, 21, or 24 which correspond
+  // to the exponents which have an official SI prefix.
+  //
+  // The exponent will be used to form the prefix part of the bank denom
+  // and will be mapped as follows:
+  //   0 - no prefix
+  //   1 - d (deci)
+  //   2 - c (centi)
+  //   3 - m (milli)
+  //   6 - u (micro)
+  //   9 - n (nano)
+  //   12 - p (pico)
+  //   15 - f (femto)
+  //   18 - a (atto)
+  //   21 - z (zepto)
+  //   24 - y (yocto)
+  uint32 exponent = 4;
+
+  // disable_auto_retire allows auto-retirement to be disabled.
+  // The credits will be auto-retired if disable_auto_retire is
+  // false unless the credits were previously put into the basket by the
+  // address picking them from the basket, in which case they will remain
+  // tradable.
+  bool disable_auto_retire = 5;
+
+  // credit_type_abbrev is the abbreviation of the credit type this basket is
+  // able to hold.
+  string credit_type_abbrev = 6;
+
+  // allowed_classes are the credit classes allowed to be put in the basket
+  repeated string allowed_classes = 7;
+
+  // date_criteria is the date criteria for batches admitted to the basket.
+  // At most, only one of the fields in the date_criteria should be set.
+  DateCriteria date_criteria = 8;
+
+  // fee is the fee that the curator will pay to create the basket. It must be
+  // >= the required Params.basket_creation_fee. We include the fee explicitly
+  // here so that the curator explicitly acknowledges paying this fee and
+  // is not surprised to learn that the paid a big fee and didn't know
+  // beforehand.
+  repeated cosmos.base.v1beta1.Coin fee = 9 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
+}
+
+// MsgCreateResponse is the Msg/Create response type.
+message MsgCreateResponse {
+
+  // basket_denom is the unique denomination ID of the newly created basket.
+  string basket_denom = 1;
+}
+
+// MsgPut is the Msg/Put request type.
+message MsgPut {
+
+  // owner is the owner of credits being put into the basket.
+  string owner = 1;
+
+  // basket_denom is the basket denom to add credits to.
+  string basket_denom = 2;
+
+  // credits are credits to add to the basket. If they do not match the basket's
+  // admission criteria the operation will fail. If there are any "dust" credits
+  // left over when converting credits to basket tokens, these credits will
+  // not be converted to basket tokens and instead remain with the owner.
+  repeated BasketCredit credits = 3;
+}
+
+// MsgPutResponse is the Msg/Put response type.
+message MsgPutResponse {
+
+  // amount_received is the integer amount of basket tokens received.
+  string amount_received = 1;
+}
+
+// MsgTake is the Msg/Take request type.
+message MsgTake {
+
+  // owner is the owner of the basket tokens.
+  string owner = 1;
+
+  // basket_denom is the basket bank denom to take credits from.
+  string basket_denom = 2;
+
+  // amount is the integer number of basket tokens to convert into credits.
+  string amount = 3;
+
+  // retirement_location is the optional retirement location for the credits
+  // which will be used only if retire_on_take is true for this basket.
+  string retirement_location = 4;
+
+  // retire_on_take is a boolean that dictates whether the ecocredits
+  // received in exchange for the basket tokens will be received as
+  // retired or tradable credits.
+  bool retire_on_take = 5;
+}
+
+// MsgTakeResponse is the Msg/Take response type.
+message MsgTakeResponse {
+
+  // credits are the credits taken out of the basket.
+  repeated BasketCredit credits = 1;
+}

--- a/packages/api/proto/regen/ecocredit/basket/v1/types.proto
+++ b/packages/api/proto/regen/ecocredit/basket/v1/types.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+
+package regen.ecocredit.basket.v1;
+
+option go_package = "github.com/regen-network/regen-ledger/x/ecocredit/basket";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+// BasketCredit represents the information for a credit batch inside a basket.
+message BasketCredit {
+
+  // batch_denom is the unique ID of the credit batch.
+  string batch_denom = 1;
+
+  // amount is the number of credits being put into or taken out of the basket.
+  // Decimal values are acceptable within the precision of the corresponding
+  //  credit type for this batch.
+  string amount = 2;
+}
+
+// DateCriteria represents the information for credit acceptance in a basket.
+// At most, only one of the values should be set.
+// NOTE: gogo proto `oneof` is not compatible with Amino signing, hence we directly define
+// both `start_date_window` and `min_start_date`. In the future, with pulsar, this should change
+// and we should use `oneof`.
+message DateCriteria {
+  // min_start_date (optional) is the earliest start date for batches of credits allowed
+  // into the basket.
+  // At most only one of `start_date_window` and `min_start_date` can be set.
+  google.protobuf.Timestamp min_start_date = 1;
+
+  // start_date_window (optional) is a duration of time measured into the past which sets
+  // a cutoff for batch start dates when adding new credits to the basket.
+  // Based on the current block timestamp, credits whose start date is before
+  // `block_timestamp - batch_date_window` will not be allowed into the basket.
+  // At most only one of `start_date_window` and `min_start_date` can be set.
+  google.protobuf.Duration start_date_window = 2;
+}
+
+// Basket represents a basket in state.
+message Basket {
+  // id is the uint64 ID of the basket. It is used internally for reducing
+  // storage space.
+  uint64 id = 1;
+
+  // basket_denom is the basket bank denom.
+  string basket_denom = 2;
+
+  // name is the unique name of the basket specified in MsgCreate. Basket
+  // names must be unique across all credit types and choices of exponent
+  // above and beyond the uniqueness constraint on basket_denom.
+  string name = 3;
+
+  // disable_auto_retire indicates whether or not the credits will be retired upon withdraw from the basket.
+  bool disable_auto_retire = 4;
+
+  // credit_type_abbrev is the abbreviation of the credit type this basket is able to hold.
+  string credit_type_abbrev = 5;
+
+  // date_criteria is the date criteria for batches admitted to the basket.
+  DateCriteria date_criteria = 6;
+
+  // exponent is the exponent for converting credits to/from basket tokens.
+  uint32 exponent = 7;
+}
+
+// BasketBalance stores the amount of credits from a batch in a basket
+message BasketBalance {
+  // basket_id is the ID of the basket
+  uint64 basket_id = 1;
+
+  // batch_denom is the denom of the credit batch
+  string batch_denom = 2;
+
+  // balance is the amount of ecocredits held in the basket
+  string balance = 3;
+
+  // batch_start_date is the start date of the batch. This field is used
+  // to create an index which is used to remove the oldest credits first.
+  google.protobuf.Timestamp batch_start_date = 4;
+}

--- a/packages/api/proto/regen/ecocredit/v1alpha1/events.proto
+++ b/packages/api/proto/regen/ecocredit/v1alpha1/events.proto
@@ -42,16 +42,18 @@ message EventCreateBatch {
   string project_location = 7;
 }
 
-// EventReceive is an event emitted when credits are received either upon
-// creation of a new batch or upon transfer. Each batch_denom created or
-// transferred will result in a separate EventReceive for easy indexing.
+// EventReceive is an event emitted when credits are received either via
+// creation of a new batch, transfer of credits, or taking credits from a
+// basket. Each batch_denom created, transferred or taken from a basket will
+// result in a separate EventReceive for easy indexing.
 message EventReceive {
+
   // sender is the sender of the credits in the case that this event is the
   // result of a transfer. It will not be set when credits are received at
-  // initial issuance.
+  // initial issuance or taken from a basket.
   string sender = 1;
 
-  // recipient is the recipient of the credits
+  // recipient is the recipient of the credits.
   string recipient = 2;
 
   // batch_denom is the unique ID of credit batch.
@@ -62,6 +64,12 @@ message EventReceive {
 
   // retired_amount is the decimal number of retired credits received.
   string retired_amount = 5;
+
+  // basket_denom is the denom of the basket. when the basket_denom field is
+  // set, it indicates that this event was triggered by the transfer of credits
+  // from a basket. It will not be set if the credits were sent by a user, or by
+  // initial issuance.
+  string basket_denom = 6;
 }
 
 // EventRetire is an event emitted when credits are retired. When credits are

--- a/packages/api/proto/regen/ecocredit/v1alpha1/types.proto
+++ b/packages/api/proto/regen/ecocredit/v1alpha1/types.proto
@@ -23,7 +23,8 @@ message ClassInfo {
   // metadata is any arbitrary metadata to attached to the credit class.
   bytes metadata = 4;
 
-  // credit_type describes the type of credit (e.g. carbon, biodiversity), as well as unit and precision.
+  // credit_type describes the type of credit (e.g. carbon, biodiversity), as
+  // well as unit and precision.
   CreditType credit_type = 5;
 
   // The number of batches issued in this credit class.
@@ -90,6 +91,12 @@ message Params {
 
   // credit_types is a list of definitions for credit types
   repeated CreditType credit_types = 4;
+
+  // basket_creation_fee is the fee to create a new basket denom.
+  repeated cosmos.base.v1beta1.Coin basket_creation_fee = 5 [
+    (gogoproto.nullable) = false,
+    (gogoproto.castrepeated) = "github.com/cosmos/cosmos-sdk/types.Coins"
+  ];
 }
 
 // CreditType defines the measurement unit/precision of a certain credit type

--- a/packages/api/proto/regen/group/v1alpha1/genesis.proto
+++ b/packages/api/proto/regen/group/v1alpha1/genesis.proto
@@ -4,6 +4,7 @@ package regen.group.v1alpha1;
 
 option go_package = "github.com/regen-network/regen-ledger/x/group";
 
+import "gogoproto/gogo.proto";
 import "regen/group/v1alpha1/types.proto";
 
 // GenesisState defines the group module's genesis state.

--- a/packages/api/proto/regen/group/v1alpha1/query.proto
+++ b/packages/api/proto/regen/group/v1alpha1/query.proto
@@ -4,6 +4,7 @@ package regen.group.v1alpha1;
 
 import "regen/group/v1alpha1/types.proto";
 import "google/api/annotations.proto";
+import "gogoproto/gogo.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 
 option go_package = "github.com/regen-network/regen-ledger/x/group";

--- a/packages/api/src/generated/regen/data/v1alpha2/genesis.ts
+++ b/packages/api/src/generated/regen/data/v1alpha2/genesis.ts
@@ -2,7 +2,11 @@
 import { messageTypeRegistry } from '../../../typeRegistry';
 import Long from 'long';
 import _m0 from 'protobufjs/minimal';
-import { ContentHash, SignerEntry } from '../../../regen/data/v1alpha2/types';
+import {
+  ContentHash,
+  Content,
+  SignerEntry,
+} from '../../../regen/data/v1alpha2/types';
 import { Timestamp } from '../../../google/protobuf/timestamp';
 
 export const protobufPackage = 'regen.data.v1alpha2';
@@ -23,6 +27,8 @@ export interface GenesisContentEntry {
   timestamp?: Date;
   /** signers are the signers, if any */
   signers: SignerEntry[];
+  /** content is the actual content if stored on-chain */
+  content?: Content;
 }
 
 function createBaseGenesisState(): GenesisState {
@@ -101,6 +107,7 @@ function createBaseGenesisContentEntry(): GenesisContentEntry {
     hash: undefined,
     timestamp: undefined,
     signers: [],
+    content: undefined,
   };
 }
 
@@ -123,6 +130,9 @@ export const GenesisContentEntry = {
     for (const v of message.signers) {
       SignerEntry.encode(v!, writer.uint32(26).fork()).ldelim();
     }
+    if (message.content !== undefined) {
+      Content.encode(message.content, writer.uint32(34).fork()).ldelim();
+    }
     return writer;
   },
 
@@ -144,6 +154,9 @@ export const GenesisContentEntry = {
         case 3:
           message.signers.push(SignerEntry.decode(reader, reader.uint32()));
           break;
+        case 4:
+          message.content = Content.decode(reader, reader.uint32());
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -162,6 +175,9 @@ export const GenesisContentEntry = {
       signers: Array.isArray(object?.signers)
         ? object.signers.map((e: any) => SignerEntry.fromJSON(e))
         : [],
+      content: isSet(object.content)
+        ? Content.fromJSON(object.content)
+        : undefined,
     };
   },
 
@@ -178,6 +194,10 @@ export const GenesisContentEntry = {
     } else {
       obj.signers = [];
     }
+    message.content !== undefined &&
+      (obj.content = message.content
+        ? Content.toJSON(message.content)
+        : undefined);
     return obj;
   },
 
@@ -192,6 +212,10 @@ export const GenesisContentEntry = {
     message.timestamp = object.timestamp ?? undefined;
     message.signers =
       object.signers?.map(e => SignerEntry.fromPartial(e)) || [];
+    message.content =
+      object.content !== undefined && object.content !== null
+        ? Content.fromPartial(object.content)
+        : undefined;
     return message;
   },
 };

--- a/packages/api/src/generated/regen/data/v1alpha2/query.ts
+++ b/packages/api/src/generated/regen/data/v1alpha2/query.ts
@@ -3,24 +3,28 @@ import { messageTypeRegistry } from '../../../typeRegistry';
 import Long from 'long';
 import _m0 from 'protobufjs/minimal';
 import {
+  ContentHash,
+  Content,
+  SignerEntry,
+} from '../../../regen/data/v1alpha2/types';
+import {
   PageRequest,
   PageResponse,
 } from '../../../cosmos/base/query/v1beta1/pagination';
-import { ContentHash } from '../../../regen/data/v1alpha2/types';
 import { Timestamp } from '../../../google/protobuf/timestamp';
 
 export const protobufPackage = 'regen.data.v1alpha2';
 
 /** QueryByContentHashRequest is the Query/ByContentHash request type. */
-export interface QueryByIRIRequest {
-  $type: 'regen.data.v1alpha2.QueryByIRIRequest';
+export interface QueryByHashRequest {
+  $type: 'regen.data.v1alpha2.QueryByHashRequest';
   /** hash is the hash-based identifier for the anchored content. */
-  iri: string;
+  hash?: ContentHash;
 }
 
 /** QueryByContentHashResponse is the Query/ByContentHash response type. */
-export interface QueryByIRIResponse {
-  $type: 'regen.data.v1alpha2.QueryByIRIResponse';
+export interface QueryByHashResponse {
+  $type: 'regen.data.v1alpha2.QueryByHashResponse';
   /** entry is the ContentEntry */
   entry?: ContentEntry;
 }
@@ -52,52 +56,38 @@ export interface ContentEntry {
   iri: string;
   /** timestamp is the anchor Timestamp */
   timestamp?: Date;
+  /** signers are the signers, if any */
+  signers: SignerEntry[];
+  /** content is the actual content if stored on-chain */
+  content?: Content;
 }
 
-/** QuerySignersRequest is the Query/Signers request type. */
-export interface QuerySignersRequest {
-  $type: 'regen.data.v1alpha2.QuerySignersRequest';
-  /** iri is the content IRI */
-  iri: string;
-  /** pagination is the PageRequest to use for pagination. */
-  pagination?: PageRequest;
+function createBaseQueryByHashRequest(): QueryByHashRequest {
+  return { $type: 'regen.data.v1alpha2.QueryByHashRequest', hash: undefined };
 }
 
-/** QuerySignersResponse is the Query/QuerySigners response type. */
-export interface QuerySignersResponse {
-  $type: 'regen.data.v1alpha2.QuerySignersResponse';
-  /** signers are the addresses of the signers. */
-  signers: string[];
-  /** pagination is the pagination PageResponse. */
-  pagination?: PageResponse;
-}
-
-function createBaseQueryByIRIRequest(): QueryByIRIRequest {
-  return { $type: 'regen.data.v1alpha2.QueryByIRIRequest', iri: '' };
-}
-
-export const QueryByIRIRequest = {
-  $type: 'regen.data.v1alpha2.QueryByIRIRequest' as const,
+export const QueryByHashRequest = {
+  $type: 'regen.data.v1alpha2.QueryByHashRequest' as const,
 
   encode(
-    message: QueryByIRIRequest,
+    message: QueryByHashRequest,
     writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
-    if (message.iri !== '') {
-      writer.uint32(10).string(message.iri);
+    if (message.hash !== undefined) {
+      ContentHash.encode(message.hash, writer.uint32(10).fork()).ldelim();
     }
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): QueryByIRIRequest {
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryByHashRequest {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseQueryByIRIRequest();
+    const message = createBaseQueryByHashRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.iri = reader.string();
+          message.hash = ContentHash.decode(reader, reader.uint32());
           break;
         default:
           reader.skipType(tag & 7);
@@ -107,39 +97,43 @@ export const QueryByIRIRequest = {
     return message;
   },
 
-  fromJSON(object: any): QueryByIRIRequest {
+  fromJSON(object: any): QueryByHashRequest {
     return {
-      $type: QueryByIRIRequest.$type,
-      iri: isSet(object.iri) ? String(object.iri) : '',
+      $type: QueryByHashRequest.$type,
+      hash: isSet(object.hash) ? ContentHash.fromJSON(object.hash) : undefined,
     };
   },
 
-  toJSON(message: QueryByIRIRequest): unknown {
+  toJSON(message: QueryByHashRequest): unknown {
     const obj: any = {};
-    message.iri !== undefined && (obj.iri = message.iri);
+    message.hash !== undefined &&
+      (obj.hash = message.hash ? ContentHash.toJSON(message.hash) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<QueryByIRIRequest>, I>>(
+  fromPartial<I extends Exact<DeepPartial<QueryByHashRequest>, I>>(
     object: I,
-  ): QueryByIRIRequest {
-    const message = createBaseQueryByIRIRequest();
-    message.iri = object.iri ?? '';
+  ): QueryByHashRequest {
+    const message = createBaseQueryByHashRequest();
+    message.hash =
+      object.hash !== undefined && object.hash !== null
+        ? ContentHash.fromPartial(object.hash)
+        : undefined;
     return message;
   },
 };
 
-messageTypeRegistry.set(QueryByIRIRequest.$type, QueryByIRIRequest);
+messageTypeRegistry.set(QueryByHashRequest.$type, QueryByHashRequest);
 
-function createBaseQueryByIRIResponse(): QueryByIRIResponse {
-  return { $type: 'regen.data.v1alpha2.QueryByIRIResponse', entry: undefined };
+function createBaseQueryByHashResponse(): QueryByHashResponse {
+  return { $type: 'regen.data.v1alpha2.QueryByHashResponse', entry: undefined };
 }
 
-export const QueryByIRIResponse = {
-  $type: 'regen.data.v1alpha2.QueryByIRIResponse' as const,
+export const QueryByHashResponse = {
+  $type: 'regen.data.v1alpha2.QueryByHashResponse' as const,
 
   encode(
-    message: QueryByIRIResponse,
+    message: QueryByHashResponse,
     writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.entry !== undefined) {
@@ -148,10 +142,10 @@ export const QueryByIRIResponse = {
     return writer;
   },
 
-  decode(input: _m0.Reader | Uint8Array, length?: number): QueryByIRIResponse {
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryByHashResponse {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseQueryByIRIResponse();
+    const message = createBaseQueryByHashResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -166,16 +160,16 @@ export const QueryByIRIResponse = {
     return message;
   },
 
-  fromJSON(object: any): QueryByIRIResponse {
+  fromJSON(object: any): QueryByHashResponse {
     return {
-      $type: QueryByIRIResponse.$type,
+      $type: QueryByHashResponse.$type,
       entry: isSet(object.entry)
         ? ContentEntry.fromJSON(object.entry)
         : undefined,
     };
   },
 
-  toJSON(message: QueryByIRIResponse): unknown {
+  toJSON(message: QueryByHashResponse): unknown {
     const obj: any = {};
     message.entry !== undefined &&
       (obj.entry = message.entry
@@ -184,10 +178,10 @@ export const QueryByIRIResponse = {
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<QueryByIRIResponse>, I>>(
+  fromPartial<I extends Exact<DeepPartial<QueryByHashResponse>, I>>(
     object: I,
-  ): QueryByIRIResponse {
-    const message = createBaseQueryByIRIResponse();
+  ): QueryByHashResponse {
+    const message = createBaseQueryByHashResponse();
     message.entry =
       object.entry !== undefined && object.entry !== null
         ? ContentEntry.fromPartial(object.entry)
@@ -196,7 +190,7 @@ export const QueryByIRIResponse = {
   },
 };
 
-messageTypeRegistry.set(QueryByIRIResponse.$type, QueryByIRIResponse);
+messageTypeRegistry.set(QueryByHashResponse.$type, QueryByHashResponse);
 
 function createBaseQueryBySignerRequest(): QueryBySignerRequest {
   return {
@@ -382,6 +376,8 @@ function createBaseContentEntry(): ContentEntry {
     hash: undefined,
     iri: '',
     timestamp: undefined,
+    signers: [],
+    content: undefined,
   };
 }
 
@@ -404,6 +400,12 @@ export const ContentEntry = {
         writer.uint32(26).fork(),
       ).ldelim();
     }
+    for (const v of message.signers) {
+      SignerEntry.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    if (message.content !== undefined) {
+      Content.encode(message.content, writer.uint32(42).fork()).ldelim();
+    }
     return writer;
   },
 
@@ -425,6 +427,12 @@ export const ContentEntry = {
             Timestamp.decode(reader, reader.uint32()),
           );
           break;
+        case 4:
+          message.signers.push(SignerEntry.decode(reader, reader.uint32()));
+          break;
+        case 5:
+          message.content = Content.decode(reader, reader.uint32());
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -441,6 +449,12 @@ export const ContentEntry = {
       timestamp: isSet(object.timestamp)
         ? fromJsonTimestamp(object.timestamp)
         : undefined,
+      signers: Array.isArray(object?.signers)
+        ? object.signers.map((e: any) => SignerEntry.fromJSON(e))
+        : [],
+      content: isSet(object.content)
+        ? Content.fromJSON(object.content)
+        : undefined,
     };
   },
 
@@ -451,6 +465,17 @@ export const ContentEntry = {
     message.iri !== undefined && (obj.iri = message.iri);
     message.timestamp !== undefined &&
       (obj.timestamp = message.timestamp.toISOString());
+    if (message.signers) {
+      obj.signers = message.signers.map(e =>
+        e ? SignerEntry.toJSON(e) : undefined,
+      );
+    } else {
+      obj.signers = [];
+    }
+    message.content !== undefined &&
+      (obj.content = message.content
+        ? Content.toJSON(message.content)
+        : undefined);
     return obj;
   },
 
@@ -464,216 +489,49 @@ export const ContentEntry = {
         : undefined;
     message.iri = object.iri ?? '';
     message.timestamp = object.timestamp ?? undefined;
+    message.signers =
+      object.signers?.map(e => SignerEntry.fromPartial(e)) || [];
+    message.content =
+      object.content !== undefined && object.content !== null
+        ? Content.fromPartial(object.content)
+        : undefined;
     return message;
   },
 };
 
 messageTypeRegistry.set(ContentEntry.$type, ContentEntry);
 
-function createBaseQuerySignersRequest(): QuerySignersRequest {
-  return {
-    $type: 'regen.data.v1alpha2.QuerySignersRequest',
-    iri: '',
-    pagination: undefined,
-  };
-}
-
-export const QuerySignersRequest = {
-  $type: 'regen.data.v1alpha2.QuerySignersRequest' as const,
-
-  encode(
-    message: QuerySignersRequest,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
-    if (message.iri !== '') {
-      writer.uint32(10).string(message.iri);
-    }
-    if (message.pagination !== undefined) {
-      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
-    }
-    return writer;
-  },
-
-  decode(input: _m0.Reader | Uint8Array, length?: number): QuerySignersRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseQuerySignersRequest();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.iri = reader.string();
-          break;
-        case 2:
-          message.pagination = PageRequest.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): QuerySignersRequest {
-    return {
-      $type: QuerySignersRequest.$type,
-      iri: isSet(object.iri) ? String(object.iri) : '',
-      pagination: isSet(object.pagination)
-        ? PageRequest.fromJSON(object.pagination)
-        : undefined,
-    };
-  },
-
-  toJSON(message: QuerySignersRequest): unknown {
-    const obj: any = {};
-    message.iri !== undefined && (obj.iri = message.iri);
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageRequest.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<QuerySignersRequest>, I>>(
-    object: I,
-  ): QuerySignersRequest {
-    const message = createBaseQuerySignersRequest();
-    message.iri = object.iri ?? '';
-    message.pagination =
-      object.pagination !== undefined && object.pagination !== null
-        ? PageRequest.fromPartial(object.pagination)
-        : undefined;
-    return message;
-  },
-};
-
-messageTypeRegistry.set(QuerySignersRequest.$type, QuerySignersRequest);
-
-function createBaseQuerySignersResponse(): QuerySignersResponse {
-  return {
-    $type: 'regen.data.v1alpha2.QuerySignersResponse',
-    signers: [],
-    pagination: undefined,
-  };
-}
-
-export const QuerySignersResponse = {
-  $type: 'regen.data.v1alpha2.QuerySignersResponse' as const,
-
-  encode(
-    message: QuerySignersResponse,
-    writer: _m0.Writer = _m0.Writer.create(),
-  ): _m0.Writer {
-    for (const v of message.signers) {
-      writer.uint32(10).string(v!);
-    }
-    if (message.pagination !== undefined) {
-      PageResponse.encode(
-        message.pagination,
-        writer.uint32(18).fork(),
-      ).ldelim();
-    }
-    return writer;
-  },
-
-  decode(
-    input: _m0.Reader | Uint8Array,
-    length?: number,
-  ): QuerySignersResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
-    let end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseQuerySignersResponse();
-    while (reader.pos < end) {
-      const tag = reader.uint32();
-      switch (tag >>> 3) {
-        case 1:
-          message.signers.push(reader.string());
-          break;
-        case 2:
-          message.pagination = PageResponse.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
-      }
-    }
-    return message;
-  },
-
-  fromJSON(object: any): QuerySignersResponse {
-    return {
-      $type: QuerySignersResponse.$type,
-      signers: Array.isArray(object?.signers)
-        ? object.signers.map((e: any) => String(e))
-        : [],
-      pagination: isSet(object.pagination)
-        ? PageResponse.fromJSON(object.pagination)
-        : undefined,
-    };
-  },
-
-  toJSON(message: QuerySignersResponse): unknown {
-    const obj: any = {};
-    if (message.signers) {
-      obj.signers = message.signers.map(e => e);
-    } else {
-      obj.signers = [];
-    }
-    message.pagination !== undefined &&
-      (obj.pagination = message.pagination
-        ? PageResponse.toJSON(message.pagination)
-        : undefined);
-    return obj;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<QuerySignersResponse>, I>>(
-    object: I,
-  ): QuerySignersResponse {
-    const message = createBaseQuerySignersResponse();
-    message.signers = object.signers?.map(e => e) || [];
-    message.pagination =
-      object.pagination !== undefined && object.pagination !== null
-        ? PageResponse.fromPartial(object.pagination)
-        : undefined;
-    return message;
-  },
-};
-
-messageTypeRegistry.set(QuerySignersResponse.$type, QuerySignersResponse);
-
 /** Query is the regen.data.v1alpha2 Query service */
 export interface Query {
   /** ByHash queries data based on its ContentHash. */
-  ByIRI(request: DeepPartial<QueryByIRIRequest>): Promise<QueryByIRIResponse>;
+  ByHash(
+    request: DeepPartial<QueryByHashRequest>,
+  ): Promise<QueryByHashResponse>;
   /** BySigner queries data based on signers. */
   BySigner(
     request: DeepPartial<QueryBySignerRequest>,
   ): Promise<QueryBySignerResponse>;
-  /** Signers queries signers based on IRI. */
-  Signers(
-    request: DeepPartial<QuerySignersRequest>,
-  ): Promise<QuerySignersResponse>;
 }
 
 export class QueryClientImpl implements Query {
   private readonly rpc: Rpc;
   constructor(rpc: Rpc) {
     this.rpc = rpc;
-    this.ByIRI = this.ByIRI.bind(this);
+    this.ByHash = this.ByHash.bind(this);
     this.BySigner = this.BySigner.bind(this);
-    this.Signers = this.Signers.bind(this);
   }
-  ByIRI(request: DeepPartial<QueryByIRIRequest>): Promise<QueryByIRIResponse> {
-    const fromPartial = QueryByIRIRequest.fromPartial(request);
-    const data = QueryByIRIRequest.encode(fromPartial).finish();
+  ByHash(
+    request: DeepPartial<QueryByHashRequest>,
+  ): Promise<QueryByHashResponse> {
+    const fromPartial = QueryByHashRequest.fromPartial(request);
+    const data = QueryByHashRequest.encode(fromPartial).finish();
     const promise = this.rpc.request(
       'regen.data.v1alpha2.Query',
-      'ByIRI',
+      'ByHash',
       data,
     );
     return promise.then(data =>
-      QueryByIRIResponse.decode(new _m0.Reader(data)),
+      QueryByHashResponse.decode(new _m0.Reader(data)),
     );
   }
 
@@ -689,21 +547,6 @@ export class QueryClientImpl implements Query {
     );
     return promise.then(data =>
       QueryBySignerResponse.decode(new _m0.Reader(data)),
-    );
-  }
-
-  Signers(
-    request: DeepPartial<QuerySignersRequest>,
-  ): Promise<QuerySignersResponse> {
-    const fromPartial = QuerySignersRequest.fromPartial(request);
-    const data = QuerySignersRequest.encode(fromPartial).finish();
-    const promise = this.rpc.request(
-      'regen.data.v1alpha2.Query',
-      'Signers',
-      data,
-    );
-    return promise.then(data =>
-      QuerySignersResponse.decode(new _m0.Reader(data)),
     );
   }
 }

--- a/packages/api/src/generated/regen/data/v1alpha2/tx.ts
+++ b/packages/api/src/generated/regen/data/v1alpha2/tx.ts
@@ -5,6 +5,7 @@ import _m0 from 'protobufjs/minimal';
 import {
   ContentHash,
   ContentHash_Graph,
+  ContentHash_Raw,
 } from '../../../regen/data/v1alpha2/types';
 import { Timestamp } from '../../../google/protobuf/timestamp';
 
@@ -28,8 +29,6 @@ export interface MsgAnchorDataResponse {
   $type: 'regen.data.v1alpha2.MsgAnchorDataResponse';
   /** timestamp is the timestamp of the block at which the data was anchored. */
   timestamp?: Date;
-  /** iri is the IRI of the data that was anchored. */
-  iri: string;
 }
 
 /** MsgSignData is the Msg/SignData request type. */
@@ -52,6 +51,26 @@ export interface MsgSignData {
 /** MsgSignDataResponse is the Msg/SignData response type. */
 export interface MsgSignDataResponse {
   $type: 'regen.data.v1alpha2.MsgSignDataResponse';
+}
+
+/** MsgStoreRawData is the Msg/StoreRawData request type. */
+export interface MsgStoreRawData {
+  $type: 'regen.data.v1alpha2.MsgStoreRawData';
+  /**
+   * sender is the address of the sender of the transaction.
+   * The sender in StoreData is not attesting to the veracity of the underlying
+   * data. They can simply be a intermediary providing services.
+   */
+  sender: string;
+  /** content_hash is the hash-based identifier for the anchored content. */
+  contentHash?: ContentHash_Raw;
+  /** content is the content of the raw data corresponding to the provided content hash. */
+  content: Uint8Array;
+}
+
+/** MsgStoreRawData is the Msg/StoreRawData response type. */
+export interface MsgStoreRawDataResponse {
+  $type: 'regen.data.v1alpha2.MsgStoreRawDataResponse';
 }
 
 function createBaseMsgAnchorData(): MsgAnchorData {
@@ -134,7 +153,6 @@ function createBaseMsgAnchorDataResponse(): MsgAnchorDataResponse {
   return {
     $type: 'regen.data.v1alpha2.MsgAnchorDataResponse',
     timestamp: undefined,
-    iri: '',
   };
 }
 
@@ -150,9 +168,6 @@ export const MsgAnchorDataResponse = {
         toTimestamp(message.timestamp),
         writer.uint32(10).fork(),
       ).ldelim();
-    }
-    if (message.iri !== '') {
-      writer.uint32(18).string(message.iri);
     }
     return writer;
   },
@@ -172,9 +187,6 @@ export const MsgAnchorDataResponse = {
             Timestamp.decode(reader, reader.uint32()),
           );
           break;
-        case 2:
-          message.iri = reader.string();
-          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -189,7 +201,6 @@ export const MsgAnchorDataResponse = {
       timestamp: isSet(object.timestamp)
         ? fromJsonTimestamp(object.timestamp)
         : undefined,
-      iri: isSet(object.iri) ? String(object.iri) : '',
     };
   },
 
@@ -197,7 +208,6 @@ export const MsgAnchorDataResponse = {
     const obj: any = {};
     message.timestamp !== undefined &&
       (obj.timestamp = message.timestamp.toISOString());
-    message.iri !== undefined && (obj.iri = message.iri);
     return obj;
   },
 
@@ -206,7 +216,6 @@ export const MsgAnchorDataResponse = {
   ): MsgAnchorDataResponse {
     const message = createBaseMsgAnchorDataResponse();
     message.timestamp = object.timestamp ?? undefined;
-    message.iri = object.iri ?? '';
     return message;
   },
 };
@@ -349,6 +358,157 @@ export const MsgSignDataResponse = {
 
 messageTypeRegistry.set(MsgSignDataResponse.$type, MsgSignDataResponse);
 
+function createBaseMsgStoreRawData(): MsgStoreRawData {
+  return {
+    $type: 'regen.data.v1alpha2.MsgStoreRawData',
+    sender: '',
+    contentHash: undefined,
+    content: new Uint8Array(),
+  };
+}
+
+export const MsgStoreRawData = {
+  $type: 'regen.data.v1alpha2.MsgStoreRawData' as const,
+
+  encode(
+    message: MsgStoreRawData,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.sender !== '') {
+      writer.uint32(10).string(message.sender);
+    }
+    if (message.contentHash !== undefined) {
+      ContentHash_Raw.encode(
+        message.contentHash,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    if (message.content.length !== 0) {
+      writer.uint32(26).bytes(message.content);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgStoreRawData {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgStoreRawData();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.sender = reader.string();
+          break;
+        case 2:
+          message.contentHash = ContentHash_Raw.decode(reader, reader.uint32());
+          break;
+        case 3:
+          message.content = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgStoreRawData {
+    return {
+      $type: MsgStoreRawData.$type,
+      sender: isSet(object.sender) ? String(object.sender) : '',
+      contentHash: isSet(object.contentHash)
+        ? ContentHash_Raw.fromJSON(object.contentHash)
+        : undefined,
+      content: isSet(object.content)
+        ? bytesFromBase64(object.content)
+        : new Uint8Array(),
+    };
+  },
+
+  toJSON(message: MsgStoreRawData): unknown {
+    const obj: any = {};
+    message.sender !== undefined && (obj.sender = message.sender);
+    message.contentHash !== undefined &&
+      (obj.contentHash = message.contentHash
+        ? ContentHash_Raw.toJSON(message.contentHash)
+        : undefined);
+    message.content !== undefined &&
+      (obj.content = base64FromBytes(
+        message.content !== undefined ? message.content : new Uint8Array(),
+      ));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgStoreRawData>, I>>(
+    object: I,
+  ): MsgStoreRawData {
+    const message = createBaseMsgStoreRawData();
+    message.sender = object.sender ?? '';
+    message.contentHash =
+      object.contentHash !== undefined && object.contentHash !== null
+        ? ContentHash_Raw.fromPartial(object.contentHash)
+        : undefined;
+    message.content = object.content ?? new Uint8Array();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgStoreRawData.$type, MsgStoreRawData);
+
+function createBaseMsgStoreRawDataResponse(): MsgStoreRawDataResponse {
+  return { $type: 'regen.data.v1alpha2.MsgStoreRawDataResponse' };
+}
+
+export const MsgStoreRawDataResponse = {
+  $type: 'regen.data.v1alpha2.MsgStoreRawDataResponse' as const,
+
+  encode(
+    _: MsgStoreRawDataResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): MsgStoreRawDataResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgStoreRawDataResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(_: any): MsgStoreRawDataResponse {
+    return {
+      $type: MsgStoreRawDataResponse.$type,
+    };
+  },
+
+  toJSON(_: MsgStoreRawDataResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgStoreRawDataResponse>, I>>(
+    _: I,
+  ): MsgStoreRawDataResponse {
+    const message = createBaseMsgStoreRawDataResponse();
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgStoreRawDataResponse.$type, MsgStoreRawDataResponse);
+
 /** Msg is the regen.data.v1alpha1 Msg service */
 export interface Msg {
   /**
@@ -385,6 +545,19 @@ export interface Msg {
    * signers and those signers will be appended to the list of signers.
    */
   SignData(request: DeepPartial<MsgSignData>): Promise<MsgSignDataResponse>;
+  /**
+   * StoreRawData stores a piece of raw data corresponding to an ContentHash.Raw on the blockchain.
+   *
+   * StoreRawData implicitly calls AnchorData if the data was not already anchored.
+   *
+   * The sender in StoreRawData is not attesting to the veracity of the underlying
+   * data. They can simply be a intermediary providing storage services.
+   * SignData should be used to create a digital signature attesting to the
+   * veracity of some piece of data.
+   */
+  StoreRawData(
+    request: DeepPartial<MsgStoreRawData>,
+  ): Promise<MsgStoreRawDataResponse>;
 }
 
 export class MsgClientImpl implements Msg {
@@ -393,6 +566,7 @@ export class MsgClientImpl implements Msg {
     this.rpc = rpc;
     this.AnchorData = this.AnchorData.bind(this);
     this.SignData = this.SignData.bind(this);
+    this.StoreRawData = this.StoreRawData.bind(this);
   }
   AnchorData(
     request: DeepPartial<MsgAnchorData>,
@@ -421,6 +595,21 @@ export class MsgClientImpl implements Msg {
       MsgSignDataResponse.decode(new _m0.Reader(data)),
     );
   }
+
+  StoreRawData(
+    request: DeepPartial<MsgStoreRawData>,
+  ): Promise<MsgStoreRawDataResponse> {
+    const fromPartial = MsgStoreRawData.fromPartial(request);
+    const data = MsgStoreRawData.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.data.v1alpha2.Msg',
+      'StoreRawData',
+      data,
+    );
+    return promise.then(data =>
+      MsgStoreRawDataResponse.decode(new _m0.Reader(data)),
+    );
+  }
 }
 
 interface Rpc {
@@ -429,6 +618,40 @@ interface Rpc {
     method: string,
     data: Uint8Array,
   ): Promise<Uint8Array>;
+}
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var globalThis: any = (() => {
+  if (typeof globalThis !== 'undefined') return globalThis;
+  if (typeof self !== 'undefined') return self;
+  if (typeof window !== 'undefined') return window;
+  if (typeof global !== 'undefined') return global;
+  throw 'Unable to locate global object';
+})();
+
+const atob: (b64: string) => string =
+  globalThis.atob ||
+  (b64 => globalThis.Buffer.from(b64, 'base64').toString('binary'));
+function bytesFromBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; ++i) {
+    arr[i] = bin.charCodeAt(i);
+  }
+  return arr;
+}
+
+const btoa: (bin: string) => string =
+  globalThis.btoa ||
+  (bin => globalThis.Buffer.from(bin, 'binary').toString('base64'));
+function base64FromBytes(arr: Uint8Array): string {
+  const bin: string[] = [];
+  for (const byte of arr) {
+    bin.push(String.fromCharCode(byte));
+  }
+  return btoa(bin.join(''));
 }
 
 type Builtin =

--- a/packages/api/src/generated/regen/data/v1alpha2/types.ts
+++ b/packages/api/src/generated/regen/data/v1alpha2/types.ts
@@ -297,6 +297,13 @@ export interface ContentHash_Graph {
   merkleTree: GraphMerkleTree;
 }
 
+/** Content is a wrapper for content stored on-chain */
+export interface Content {
+  $type: 'regen.data.v1alpha2.Content';
+  /** raw_data is the oneof field for raw data */
+  rawData: Uint8Array | undefined;
+}
+
 /** SignerEntry is a signer entry wrapping a signer address and timestamp */
 export interface SignerEntry {
   $type: 'regen.data.v1alpha2.SignerEntry';
@@ -595,6 +602,69 @@ export const ContentHash_Graph = {
 };
 
 messageTypeRegistry.set(ContentHash_Graph.$type, ContentHash_Graph);
+
+function createBaseContent(): Content {
+  return { $type: 'regen.data.v1alpha2.Content', rawData: undefined };
+}
+
+export const Content = {
+  $type: 'regen.data.v1alpha2.Content' as const,
+
+  encode(
+    message: Content,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.rawData !== undefined) {
+      writer.uint32(10).bytes(message.rawData);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Content {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseContent();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.rawData = reader.bytes();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Content {
+    return {
+      $type: Content.$type,
+      rawData: isSet(object.rawData)
+        ? bytesFromBase64(object.rawData)
+        : undefined,
+    };
+  },
+
+  toJSON(message: Content): unknown {
+    const obj: any = {};
+    message.rawData !== undefined &&
+      (obj.rawData =
+        message.rawData !== undefined
+          ? base64FromBytes(message.rawData)
+          : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Content>, I>>(object: I): Content {
+    const message = createBaseContent();
+    message.rawData = object.rawData ?? undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Content.$type, Content);
 
 function createBaseSignerEntry(): SignerEntry {
   return {

--- a/packages/api/src/generated/regen/ecocredit/basket/v1/events.ts
+++ b/packages/api/src/generated/regen/ecocredit/basket/v1/events.ts
@@ -1,0 +1,364 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { BasketCredit } from '../../../../regen/ecocredit/basket/v1/types';
+
+export const protobufPackage = 'regen.ecocredit.basket.v1';
+
+/** EventCreate is an event emitted when a basket is created. */
+export interface EventCreate {
+  $type: 'regen.ecocredit.basket.v1.EventCreate';
+  /** basket_denom is the basket bank denom. */
+  basketDenom: string;
+  /**
+   * curator is the address of the basket curator who is able to change certain
+   * basket settings.
+   */
+  curator: string;
+}
+
+/**
+ * EventPut is an event emitted when credits are put into a basket in return
+ * for basket tokens.
+ */
+export interface EventPut {
+  $type: 'regen.ecocredit.basket.v1.EventPut';
+  /** owner is the owner of the credits put into the basket. */
+  owner: string;
+  /** basket_denom is the basket bank denom that the credits were added to. */
+  basketDenom: string;
+  /** credits are the credits that were added to the basket. */
+  credits: BasketCredit[];
+  /** amount is the integer number of basket tokens converted from credits. */
+  amount: string;
+}
+
+/**
+ * EventTake is an event emitted when credits are taken from a basket starting
+ * from the oldest credits first.
+ */
+export interface EventTake {
+  $type: 'regen.ecocredit.basket.v1.EventTake';
+  /** owner is the owner of the credits taken from the basket. */
+  owner: string;
+  /** basket_denom is the basket bank denom that credits were taken from. */
+  basketDenom: string;
+  /** credits are the credits that were taken from the basket. */
+  credits: BasketCredit[];
+  /** amount is the integer number of basket tokens converted to credits. */
+  amount: string;
+}
+
+function createBaseEventCreate(): EventCreate {
+  return {
+    $type: 'regen.ecocredit.basket.v1.EventCreate',
+    basketDenom: '',
+    curator: '',
+  };
+}
+
+export const EventCreate = {
+  $type: 'regen.ecocredit.basket.v1.EventCreate' as const,
+
+  encode(
+    message: EventCreate,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.basketDenom !== '') {
+      writer.uint32(10).string(message.basketDenom);
+    }
+    if (message.curator !== '') {
+      writer.uint32(18).string(message.curator);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): EventCreate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventCreate();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basketDenom = reader.string();
+          break;
+        case 2:
+          message.curator = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): EventCreate {
+    return {
+      $type: EventCreate.$type,
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      curator: isSet(object.curator) ? String(object.curator) : '',
+    };
+  },
+
+  toJSON(message: EventCreate): unknown {
+    const obj: any = {};
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    message.curator !== undefined && (obj.curator = message.curator);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<EventCreate>, I>>(
+    object: I,
+  ): EventCreate {
+    const message = createBaseEventCreate();
+    message.basketDenom = object.basketDenom ?? '';
+    message.curator = object.curator ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(EventCreate.$type, EventCreate);
+
+function createBaseEventPut(): EventPut {
+  return {
+    $type: 'regen.ecocredit.basket.v1.EventPut',
+    owner: '',
+    basketDenom: '',
+    credits: [],
+    amount: '',
+  };
+}
+
+export const EventPut = {
+  $type: 'regen.ecocredit.basket.v1.EventPut' as const,
+
+  encode(
+    message: EventPut,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.basketDenom !== '') {
+      writer.uint32(18).string(message.basketDenom);
+    }
+    for (const v of message.credits) {
+      BasketCredit.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    if (message.amount !== '') {
+      writer.uint32(34).string(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): EventPut {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventPut();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.basketDenom = reader.string();
+          break;
+        case 3:
+          message.credits.push(BasketCredit.decode(reader, reader.uint32()));
+          break;
+        case 4:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): EventPut {
+    return {
+      $type: EventPut.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      credits: Array.isArray(object?.credits)
+        ? object.credits.map((e: any) => BasketCredit.fromJSON(e))
+        : [],
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: EventPut): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    if (message.credits) {
+      obj.credits = message.credits.map(e =>
+        e ? BasketCredit.toJSON(e) : undefined,
+      );
+    } else {
+      obj.credits = [];
+    }
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<EventPut>, I>>(object: I): EventPut {
+    const message = createBaseEventPut();
+    message.owner = object.owner ?? '';
+    message.basketDenom = object.basketDenom ?? '';
+    message.credits =
+      object.credits?.map(e => BasketCredit.fromPartial(e)) || [];
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(EventPut.$type, EventPut);
+
+function createBaseEventTake(): EventTake {
+  return {
+    $type: 'regen.ecocredit.basket.v1.EventTake',
+    owner: '',
+    basketDenom: '',
+    credits: [],
+    amount: '',
+  };
+}
+
+export const EventTake = {
+  $type: 'regen.ecocredit.basket.v1.EventTake' as const,
+
+  encode(
+    message: EventTake,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.basketDenom !== '') {
+      writer.uint32(18).string(message.basketDenom);
+    }
+    for (const v of message.credits) {
+      BasketCredit.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    if (message.amount !== '') {
+      writer.uint32(34).string(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): EventTake {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseEventTake();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.basketDenom = reader.string();
+          break;
+        case 3:
+          message.credits.push(BasketCredit.decode(reader, reader.uint32()));
+          break;
+        case 4:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): EventTake {
+    return {
+      $type: EventTake.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      credits: Array.isArray(object?.credits)
+        ? object.credits.map((e: any) => BasketCredit.fromJSON(e))
+        : [],
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: EventTake): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    if (message.credits) {
+      obj.credits = message.credits.map(e =>
+        e ? BasketCredit.toJSON(e) : undefined,
+      );
+    } else {
+      obj.credits = [];
+    }
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<EventTake>, I>>(
+    object: I,
+  ): EventTake {
+    const message = createBaseEventTake();
+    message.owner = object.owner ?? '';
+    message.basketDenom = object.basketDenom ?? '';
+    message.credits =
+      object.credits?.map(e => BasketCredit.fromPartial(e)) || [];
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(EventTake.$type, EventTake);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/api/src/generated/regen/ecocredit/basket/v1/query.ts
+++ b/packages/api/src/generated/regen/ecocredit/basket/v1/query.ts
@@ -1,0 +1,857 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import {
+  Basket,
+  BasketBalance,
+} from '../../../../regen/ecocredit/basket/v1/types';
+import {
+  PageRequest,
+  PageResponse,
+} from '../../../../cosmos/base/query/v1beta1/pagination';
+
+export const protobufPackage = 'regen.ecocredit.basket.v1';
+
+/** QueryBasketRequest is the Query/Basket request type. */
+export interface QueryBasketRequest {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketRequest';
+  /** basket_denom represents the denom of the basket to query. */
+  basketDenom: string;
+}
+
+/** QueryBasketResponse is the Query/Basket response type. */
+export interface QueryBasketResponse {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketResponse';
+  /** basket is the queried basket. */
+  basket?: Basket;
+  /** classes are the credit classes that can be deposited in the basket. */
+  classes: string[];
+}
+
+/** QueryBasketsRequest is the Query/Baskets request type. */
+export interface QueryBasketsRequest {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketsRequest';
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryBasketsResponse is the Query/Baskets response type. */
+export interface QueryBasketsResponse {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketsResponse';
+  /** baskets are the fetched baskets. */
+  baskets: Basket[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryBasketBalancesRequest is the Query/BasketBalances request type. */
+export interface QueryBasketBalancesRequest {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalancesRequest';
+  /** basket_denom is the denom of the basket. */
+  basketDenom: string;
+  /** pagination defines an optional pagination for the request. */
+  pagination?: PageRequest;
+}
+
+/** QueryBasketBalancesResponse is the Query/BasketBalances response type. */
+export interface QueryBasketBalancesResponse {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalancesResponse';
+  /** balances is a list of credit balances in the basket. */
+  balances: BasketBalance[];
+  /** pagination defines the pagination in the response. */
+  pagination?: PageResponse;
+}
+
+/** QueryBasketBalanceRequest is the Query/BasketBalance request type. */
+export interface QueryBasketBalanceRequest {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalanceRequest';
+  /** basket_denom is the denom of the basket. */
+  basketDenom: string;
+  /** batch_denom is the denom of the credit batch. */
+  batchDenom: string;
+}
+
+/** QueryBasketBalanceResponse is the Query/BasketBalance response type. */
+export interface QueryBasketBalanceResponse {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalanceResponse';
+  /** balance is the amount of the queried credit batch in the basket. */
+  balance: string;
+}
+
+function createBaseQueryBasketRequest(): QueryBasketRequest {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketRequest',
+    basketDenom: '',
+  };
+}
+
+export const QueryBasketRequest = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketRequest' as const,
+
+  encode(
+    message: QueryBasketRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.basketDenom !== '') {
+      writer.uint32(10).string(message.basketDenom);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryBasketRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basketDenom = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketRequest {
+    return {
+      $type: QueryBasketRequest.$type,
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+    };
+  },
+
+  toJSON(message: QueryBasketRequest): unknown {
+    const obj: any = {};
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketRequest>, I>>(
+    object: I,
+  ): QueryBasketRequest {
+    const message = createBaseQueryBasketRequest();
+    message.basketDenom = object.basketDenom ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryBasketRequest.$type, QueryBasketRequest);
+
+function createBaseQueryBasketResponse(): QueryBasketResponse {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketResponse',
+    basket: undefined,
+    classes: [],
+  };
+}
+
+export const QueryBasketResponse = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketResponse' as const,
+
+  encode(
+    message: QueryBasketResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.basket !== undefined) {
+      Basket.encode(message.basket, writer.uint32(10).fork()).ldelim();
+    }
+    for (const v of message.classes) {
+      writer.uint32(18).string(v!);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryBasketResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basket = Basket.decode(reader, reader.uint32());
+          break;
+        case 2:
+          message.classes.push(reader.string());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketResponse {
+    return {
+      $type: QueryBasketResponse.$type,
+      basket: isSet(object.basket) ? Basket.fromJSON(object.basket) : undefined,
+      classes: Array.isArray(object?.classes)
+        ? object.classes.map((e: any) => String(e))
+        : [],
+    };
+  },
+
+  toJSON(message: QueryBasketResponse): unknown {
+    const obj: any = {};
+    message.basket !== undefined &&
+      (obj.basket = message.basket ? Basket.toJSON(message.basket) : undefined);
+    if (message.classes) {
+      obj.classes = message.classes.map(e => e);
+    } else {
+      obj.classes = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketResponse>, I>>(
+    object: I,
+  ): QueryBasketResponse {
+    const message = createBaseQueryBasketResponse();
+    message.basket =
+      object.basket !== undefined && object.basket !== null
+        ? Basket.fromPartial(object.basket)
+        : undefined;
+    message.classes = object.classes?.map(e => e) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryBasketResponse.$type, QueryBasketResponse);
+
+function createBaseQueryBasketsRequest(): QueryBasketsRequest {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketsRequest',
+    pagination: undefined,
+  };
+}
+
+export const QueryBasketsRequest = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketsRequest' as const,
+
+  encode(
+    message: QueryBasketsRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): QueryBasketsRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketsRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketsRequest {
+    return {
+      $type: QueryBasketsRequest.$type,
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryBasketsRequest): unknown {
+    const obj: any = {};
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketsRequest>, I>>(
+    object: I,
+  ): QueryBasketsRequest {
+    const message = createBaseQueryBasketsRequest();
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryBasketsRequest.$type, QueryBasketsRequest);
+
+function createBaseQueryBasketsResponse(): QueryBasketsResponse {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketsResponse',
+    baskets: [],
+    pagination: undefined,
+  };
+}
+
+export const QueryBasketsResponse = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketsResponse' as const,
+
+  encode(
+    message: QueryBasketsResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.baskets) {
+      Basket.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryBasketsResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketsResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.baskets.push(Basket.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketsResponse {
+    return {
+      $type: QueryBasketsResponse.$type,
+      baskets: Array.isArray(object?.baskets)
+        ? object.baskets.map((e: any) => Basket.fromJSON(e))
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryBasketsResponse): unknown {
+    const obj: any = {};
+    if (message.baskets) {
+      obj.baskets = message.baskets.map(e =>
+        e ? Basket.toJSON(e) : undefined,
+      );
+    } else {
+      obj.baskets = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketsResponse>, I>>(
+    object: I,
+  ): QueryBasketsResponse {
+    const message = createBaseQueryBasketsResponse();
+    message.baskets = object.baskets?.map(e => Basket.fromPartial(e)) || [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(QueryBasketsResponse.$type, QueryBasketsResponse);
+
+function createBaseQueryBasketBalancesRequest(): QueryBasketBalancesRequest {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketBalancesRequest',
+    basketDenom: '',
+    pagination: undefined,
+  };
+}
+
+export const QueryBasketBalancesRequest = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalancesRequest' as const,
+
+  encode(
+    message: QueryBasketBalancesRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.basketDenom !== '') {
+      writer.uint32(10).string(message.basketDenom);
+    }
+    if (message.pagination !== undefined) {
+      PageRequest.encode(message.pagination, writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryBasketBalancesRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketBalancesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basketDenom = reader.string();
+          break;
+        case 2:
+          message.pagination = PageRequest.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketBalancesRequest {
+    return {
+      $type: QueryBasketBalancesRequest.$type,
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      pagination: isSet(object.pagination)
+        ? PageRequest.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryBasketBalancesRequest): unknown {
+    const obj: any = {};
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageRequest.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketBalancesRequest>, I>>(
+    object: I,
+  ): QueryBasketBalancesRequest {
+    const message = createBaseQueryBasketBalancesRequest();
+    message.basketDenom = object.basketDenom ?? '';
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageRequest.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryBasketBalancesRequest.$type,
+  QueryBasketBalancesRequest,
+);
+
+function createBaseQueryBasketBalancesResponse(): QueryBasketBalancesResponse {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketBalancesResponse',
+    balances: [],
+    pagination: undefined,
+  };
+}
+
+export const QueryBasketBalancesResponse = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalancesResponse' as const,
+
+  encode(
+    message: QueryBasketBalancesResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.balances) {
+      BasketBalance.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    if (message.pagination !== undefined) {
+      PageResponse.encode(
+        message.pagination,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryBasketBalancesResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketBalancesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.balances.push(BasketBalance.decode(reader, reader.uint32()));
+          break;
+        case 2:
+          message.pagination = PageResponse.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketBalancesResponse {
+    return {
+      $type: QueryBasketBalancesResponse.$type,
+      balances: Array.isArray(object?.balances)
+        ? object.balances.map((e: any) => BasketBalance.fromJSON(e))
+        : [],
+      pagination: isSet(object.pagination)
+        ? PageResponse.fromJSON(object.pagination)
+        : undefined,
+    };
+  },
+
+  toJSON(message: QueryBasketBalancesResponse): unknown {
+    const obj: any = {};
+    if (message.balances) {
+      obj.balances = message.balances.map(e =>
+        e ? BasketBalance.toJSON(e) : undefined,
+      );
+    } else {
+      obj.balances = [];
+    }
+    message.pagination !== undefined &&
+      (obj.pagination = message.pagination
+        ? PageResponse.toJSON(message.pagination)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketBalancesResponse>, I>>(
+    object: I,
+  ): QueryBasketBalancesResponse {
+    const message = createBaseQueryBasketBalancesResponse();
+    message.balances =
+      object.balances?.map(e => BasketBalance.fromPartial(e)) || [];
+    message.pagination =
+      object.pagination !== undefined && object.pagination !== null
+        ? PageResponse.fromPartial(object.pagination)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryBasketBalancesResponse.$type,
+  QueryBasketBalancesResponse,
+);
+
+function createBaseQueryBasketBalanceRequest(): QueryBasketBalanceRequest {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketBalanceRequest',
+    basketDenom: '',
+    batchDenom: '',
+  };
+}
+
+export const QueryBasketBalanceRequest = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalanceRequest' as const,
+
+  encode(
+    message: QueryBasketBalanceRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.basketDenom !== '') {
+      writer.uint32(10).string(message.basketDenom);
+    }
+    if (message.batchDenom !== '') {
+      writer.uint32(18).string(message.batchDenom);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryBasketBalanceRequest {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketBalanceRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basketDenom = reader.string();
+          break;
+        case 2:
+          message.batchDenom = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketBalanceRequest {
+    return {
+      $type: QueryBasketBalanceRequest.$type,
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      batchDenom: isSet(object.batchDenom) ? String(object.batchDenom) : '',
+    };
+  },
+
+  toJSON(message: QueryBasketBalanceRequest): unknown {
+    const obj: any = {};
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    message.batchDenom !== undefined && (obj.batchDenom = message.batchDenom);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketBalanceRequest>, I>>(
+    object: I,
+  ): QueryBasketBalanceRequest {
+    const message = createBaseQueryBasketBalanceRequest();
+    message.basketDenom = object.basketDenom ?? '';
+    message.batchDenom = object.batchDenom ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryBasketBalanceRequest.$type,
+  QueryBasketBalanceRequest,
+);
+
+function createBaseQueryBasketBalanceResponse(): QueryBasketBalanceResponse {
+  return {
+    $type: 'regen.ecocredit.basket.v1.QueryBasketBalanceResponse',
+    balance: '',
+  };
+}
+
+export const QueryBasketBalanceResponse = {
+  $type: 'regen.ecocredit.basket.v1.QueryBasketBalanceResponse' as const,
+
+  encode(
+    message: QueryBasketBalanceResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.balance !== '') {
+      writer.uint32(10).string(message.balance);
+    }
+    return writer;
+  },
+
+  decode(
+    input: _m0.Reader | Uint8Array,
+    length?: number,
+  ): QueryBasketBalanceResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseQueryBasketBalanceResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.balance = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): QueryBasketBalanceResponse {
+    return {
+      $type: QueryBasketBalanceResponse.$type,
+      balance: isSet(object.balance) ? String(object.balance) : '',
+    };
+  },
+
+  toJSON(message: QueryBasketBalanceResponse): unknown {
+    const obj: any = {};
+    message.balance !== undefined && (obj.balance = message.balance);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<QueryBasketBalanceResponse>, I>>(
+    object: I,
+  ): QueryBasketBalanceResponse {
+    const message = createBaseQueryBasketBalanceResponse();
+    message.balance = object.balance ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(
+  QueryBasketBalanceResponse.$type,
+  QueryBasketBalanceResponse,
+);
+
+/** Msg is the regen.ecocredit.basket.v1beta1 Query service. */
+export interface Query {
+  /** Basket queries one basket by denom. */
+  Basket(
+    request: DeepPartial<QueryBasketRequest>,
+  ): Promise<QueryBasketResponse>;
+  /** Baskets lists all baskets in the ecocredit module. */
+  Baskets(
+    request: DeepPartial<QueryBasketsRequest>,
+  ): Promise<QueryBasketsResponse>;
+  /** BasketBalances lists the balance of each credit batch in the basket. */
+  BasketBalances(
+    request: DeepPartial<QueryBasketBalancesRequest>,
+  ): Promise<QueryBasketBalancesResponse>;
+  /** BasketBalance queries the balance of a specific credit batch in the basket. */
+  BasketBalance(
+    request: DeepPartial<QueryBasketBalanceRequest>,
+  ): Promise<QueryBasketBalanceResponse>;
+}
+
+export class QueryClientImpl implements Query {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.Basket = this.Basket.bind(this);
+    this.Baskets = this.Baskets.bind(this);
+    this.BasketBalances = this.BasketBalances.bind(this);
+    this.BasketBalance = this.BasketBalance.bind(this);
+  }
+  Basket(
+    request: DeepPartial<QueryBasketRequest>,
+  ): Promise<QueryBasketResponse> {
+    const fromPartial = QueryBasketRequest.fromPartial(request);
+    const data = QueryBasketRequest.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Query',
+      'Basket',
+      data,
+    );
+    return promise.then(data =>
+      QueryBasketResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  Baskets(
+    request: DeepPartial<QueryBasketsRequest>,
+  ): Promise<QueryBasketsResponse> {
+    const fromPartial = QueryBasketsRequest.fromPartial(request);
+    const data = QueryBasketsRequest.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Query',
+      'Baskets',
+      data,
+    );
+    return promise.then(data =>
+      QueryBasketsResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  BasketBalances(
+    request: DeepPartial<QueryBasketBalancesRequest>,
+  ): Promise<QueryBasketBalancesResponse> {
+    const fromPartial = QueryBasketBalancesRequest.fromPartial(request);
+    const data = QueryBasketBalancesRequest.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Query',
+      'BasketBalances',
+      data,
+    );
+    return promise.then(data =>
+      QueryBasketBalancesResponse.decode(new _m0.Reader(data)),
+    );
+  }
+
+  BasketBalance(
+    request: DeepPartial<QueryBasketBalanceRequest>,
+  ): Promise<QueryBasketBalanceResponse> {
+    const fromPartial = QueryBasketBalanceRequest.fromPartial(request);
+    const data = QueryBasketBalanceRequest.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Query',
+      'BasketBalance',
+      data,
+    );
+    return promise.then(data =>
+      QueryBasketBalanceResponse.decode(new _m0.Reader(data)),
+    );
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/api/src/generated/regen/ecocredit/basket/v1/tx.ts
+++ b/packages/api/src/generated/regen/ecocredit/basket/v1/tx.ts
@@ -1,0 +1,817 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import {
+  DateCriteria,
+  BasketCredit,
+} from '../../../../regen/ecocredit/basket/v1/types';
+import { Coin } from '../../../../cosmos/base/v1beta1/coin';
+
+export const protobufPackage = 'regen.ecocredit.basket.v1';
+
+/** MsgCreate is the Msg/Create request type. */
+export interface MsgCreate {
+  $type: 'regen.ecocredit.basket.v1.MsgCreate';
+  /**
+   * curator is the address of the basket curator who is able to change certain
+   * basket settings.
+   */
+  curator: string;
+  /**
+   * name will be used to together with prefix to create a bank denom for this
+   * basket token. It can be between 3-8 alphanumeric characters, with the
+   * first character being alphabetic.
+   *
+   * The bank denom will be formed from name, credit type and exponent and be
+   * of the form `eco.<prefix><credit_type_abbrev>.<name>` where prefix
+   * is derived from exponent.
+   */
+  name: string;
+  /**
+   * description is a human-readable description of the basket denom that should
+   * be at most 256 characters.
+   */
+  description: string;
+  /**
+   * exponent is the exponent that will be used for converting credits to basket
+   * tokens and for bank denom metadata. It also limits the precision of
+   * credit amounts when putting credits into a basket. An exponent of 6 will
+   * mean that 10^6 units of a basket token will be issued for 1.0 credits and that
+   * this should be displayed as one unit in user interfaces. It also means
+   * that the maximum precision of credit amounts is 6 decimal places so that
+   * the need to round is eliminated. The exponent must be >= the precision of
+   * the credit type at the time the basket is created and be of one of the
+   * following values 0, 1, 2, 3, 6, 9, 12, 15, 18, 21, or 24 which correspond
+   * to the exponents which have an official SI prefix.
+   *
+   * The exponent will be used to form the prefix part of the bank denom
+   * and will be mapped as follows:
+   *   0 - no prefix
+   *   1 - d (deci)
+   *   2 - c (centi)
+   *   3 - m (milli)
+   *   6 - u (micro)
+   *   9 - n (nano)
+   *   12 - p (pico)
+   *   15 - f (femto)
+   *   18 - a (atto)
+   *   21 - z (zepto)
+   *   24 - y (yocto)
+   */
+  exponent: number;
+  /**
+   * disable_auto_retire allows auto-retirement to be disabled.
+   * The credits will be auto-retired if disable_auto_retire is
+   * false unless the credits were previously put into the basket by the
+   * address picking them from the basket, in which case they will remain
+   * tradable.
+   */
+  disableAutoRetire: boolean;
+  /**
+   * credit_type_abbrev is the abbreviation of the credit type this basket is
+   * able to hold.
+   */
+  creditTypeAbbrev: string;
+  /** allowed_classes are the credit classes allowed to be put in the basket */
+  allowedClasses: string[];
+  /**
+   * date_criteria is the date criteria for batches admitted to the basket.
+   * At most, only one of the fields in the date_criteria should be set.
+   */
+  dateCriteria?: DateCriteria;
+  /**
+   * fee is the fee that the curator will pay to create the basket. It must be
+   * >= the required Params.basket_creation_fee. We include the fee explicitly
+   * here so that the curator explicitly acknowledges paying this fee and
+   * is not surprised to learn that the paid a big fee and didn't know
+   * beforehand.
+   */
+  fee: Coin[];
+}
+
+/** MsgCreateResponse is the Msg/Create response type. */
+export interface MsgCreateResponse {
+  $type: 'regen.ecocredit.basket.v1.MsgCreateResponse';
+  /** basket_denom is the unique denomination ID of the newly created basket. */
+  basketDenom: string;
+}
+
+/** MsgPut is the Msg/Put request type. */
+export interface MsgPut {
+  $type: 'regen.ecocredit.basket.v1.MsgPut';
+  /** owner is the owner of credits being put into the basket. */
+  owner: string;
+  /** basket_denom is the basket denom to add credits to. */
+  basketDenom: string;
+  /**
+   * credits are credits to add to the basket. If they do not match the basket's
+   * admission criteria the operation will fail. If there are any "dust" credits
+   * left over when converting credits to basket tokens, these credits will
+   * not be converted to basket tokens and instead remain with the owner.
+   */
+  credits: BasketCredit[];
+}
+
+/** MsgPutResponse is the Msg/Put response type. */
+export interface MsgPutResponse {
+  $type: 'regen.ecocredit.basket.v1.MsgPutResponse';
+  /** amount_received is the integer amount of basket tokens received. */
+  amountReceived: string;
+}
+
+/** MsgTake is the Msg/Take request type. */
+export interface MsgTake {
+  $type: 'regen.ecocredit.basket.v1.MsgTake';
+  /** owner is the owner of the basket tokens. */
+  owner: string;
+  /** basket_denom is the basket bank denom to take credits from. */
+  basketDenom: string;
+  /** amount is the integer number of basket tokens to convert into credits. */
+  amount: string;
+  /**
+   * retirement_location is the optional retirement location for the credits
+   * which will be used only if retire_on_take is true for this basket.
+   */
+  retirementLocation: string;
+  /**
+   * retire_on_take is a boolean that dictates whether the ecocredits
+   * received in exchange for the basket tokens will be received as
+   * retired or tradable credits.
+   */
+  retireOnTake: boolean;
+}
+
+/** MsgTakeResponse is the Msg/Take response type. */
+export interface MsgTakeResponse {
+  $type: 'regen.ecocredit.basket.v1.MsgTakeResponse';
+  /** credits are the credits taken out of the basket. */
+  credits: BasketCredit[];
+}
+
+function createBaseMsgCreate(): MsgCreate {
+  return {
+    $type: 'regen.ecocredit.basket.v1.MsgCreate',
+    curator: '',
+    name: '',
+    description: '',
+    exponent: 0,
+    disableAutoRetire: false,
+    creditTypeAbbrev: '',
+    allowedClasses: [],
+    dateCriteria: undefined,
+    fee: [],
+  };
+}
+
+export const MsgCreate = {
+  $type: 'regen.ecocredit.basket.v1.MsgCreate' as const,
+
+  encode(
+    message: MsgCreate,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.curator !== '') {
+      writer.uint32(10).string(message.curator);
+    }
+    if (message.name !== '') {
+      writer.uint32(18).string(message.name);
+    }
+    if (message.description !== '') {
+      writer.uint32(26).string(message.description);
+    }
+    if (message.exponent !== 0) {
+      writer.uint32(32).uint32(message.exponent);
+    }
+    if (message.disableAutoRetire === true) {
+      writer.uint32(40).bool(message.disableAutoRetire);
+    }
+    if (message.creditTypeAbbrev !== '') {
+      writer.uint32(50).string(message.creditTypeAbbrev);
+    }
+    for (const v of message.allowedClasses) {
+      writer.uint32(58).string(v!);
+    }
+    if (message.dateCriteria !== undefined) {
+      DateCriteria.encode(
+        message.dateCriteria,
+        writer.uint32(66).fork(),
+      ).ldelim();
+    }
+    for (const v of message.fee) {
+      Coin.encode(v!, writer.uint32(74).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreate {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreate();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.curator = reader.string();
+          break;
+        case 2:
+          message.name = reader.string();
+          break;
+        case 3:
+          message.description = reader.string();
+          break;
+        case 4:
+          message.exponent = reader.uint32();
+          break;
+        case 5:
+          message.disableAutoRetire = reader.bool();
+          break;
+        case 6:
+          message.creditTypeAbbrev = reader.string();
+          break;
+        case 7:
+          message.allowedClasses.push(reader.string());
+          break;
+        case 8:
+          message.dateCriteria = DateCriteria.decode(reader, reader.uint32());
+          break;
+        case 9:
+          message.fee.push(Coin.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreate {
+    return {
+      $type: MsgCreate.$type,
+      curator: isSet(object.curator) ? String(object.curator) : '',
+      name: isSet(object.name) ? String(object.name) : '',
+      description: isSet(object.description) ? String(object.description) : '',
+      exponent: isSet(object.exponent) ? Number(object.exponent) : 0,
+      disableAutoRetire: isSet(object.disableAutoRetire)
+        ? Boolean(object.disableAutoRetire)
+        : false,
+      creditTypeAbbrev: isSet(object.creditTypeAbbrev)
+        ? String(object.creditTypeAbbrev)
+        : '',
+      allowedClasses: Array.isArray(object?.allowedClasses)
+        ? object.allowedClasses.map((e: any) => String(e))
+        : [],
+      dateCriteria: isSet(object.dateCriteria)
+        ? DateCriteria.fromJSON(object.dateCriteria)
+        : undefined,
+      fee: Array.isArray(object?.fee)
+        ? object.fee.map((e: any) => Coin.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: MsgCreate): unknown {
+    const obj: any = {};
+    message.curator !== undefined && (obj.curator = message.curator);
+    message.name !== undefined && (obj.name = message.name);
+    message.description !== undefined &&
+      (obj.description = message.description);
+    message.exponent !== undefined &&
+      (obj.exponent = Math.round(message.exponent));
+    message.disableAutoRetire !== undefined &&
+      (obj.disableAutoRetire = message.disableAutoRetire);
+    message.creditTypeAbbrev !== undefined &&
+      (obj.creditTypeAbbrev = message.creditTypeAbbrev);
+    if (message.allowedClasses) {
+      obj.allowedClasses = message.allowedClasses.map(e => e);
+    } else {
+      obj.allowedClasses = [];
+    }
+    message.dateCriteria !== undefined &&
+      (obj.dateCriteria = message.dateCriteria
+        ? DateCriteria.toJSON(message.dateCriteria)
+        : undefined);
+    if (message.fee) {
+      obj.fee = message.fee.map(e => (e ? Coin.toJSON(e) : undefined));
+    } else {
+      obj.fee = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreate>, I>>(
+    object: I,
+  ): MsgCreate {
+    const message = createBaseMsgCreate();
+    message.curator = object.curator ?? '';
+    message.name = object.name ?? '';
+    message.description = object.description ?? '';
+    message.exponent = object.exponent ?? 0;
+    message.disableAutoRetire = object.disableAutoRetire ?? false;
+    message.creditTypeAbbrev = object.creditTypeAbbrev ?? '';
+    message.allowedClasses = object.allowedClasses?.map(e => e) || [];
+    message.dateCriteria =
+      object.dateCriteria !== undefined && object.dateCriteria !== null
+        ? DateCriteria.fromPartial(object.dateCriteria)
+        : undefined;
+    message.fee = object.fee?.map(e => Coin.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreate.$type, MsgCreate);
+
+function createBaseMsgCreateResponse(): MsgCreateResponse {
+  return {
+    $type: 'regen.ecocredit.basket.v1.MsgCreateResponse',
+    basketDenom: '',
+  };
+}
+
+export const MsgCreateResponse = {
+  $type: 'regen.ecocredit.basket.v1.MsgCreateResponse' as const,
+
+  encode(
+    message: MsgCreateResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.basketDenom !== '') {
+      writer.uint32(10).string(message.basketDenom);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgCreateResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgCreateResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basketDenom = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgCreateResponse {
+    return {
+      $type: MsgCreateResponse.$type,
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+    };
+  },
+
+  toJSON(message: MsgCreateResponse): unknown {
+    const obj: any = {};
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgCreateResponse>, I>>(
+    object: I,
+  ): MsgCreateResponse {
+    const message = createBaseMsgCreateResponse();
+    message.basketDenom = object.basketDenom ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgCreateResponse.$type, MsgCreateResponse);
+
+function createBaseMsgPut(): MsgPut {
+  return {
+    $type: 'regen.ecocredit.basket.v1.MsgPut',
+    owner: '',
+    basketDenom: '',
+    credits: [],
+  };
+}
+
+export const MsgPut = {
+  $type: 'regen.ecocredit.basket.v1.MsgPut' as const,
+
+  encode(
+    message: MsgPut,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.basketDenom !== '') {
+      writer.uint32(18).string(message.basketDenom);
+    }
+    for (const v of message.credits) {
+      BasketCredit.encode(v!, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgPut {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgPut();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.basketDenom = reader.string();
+          break;
+        case 3:
+          message.credits.push(BasketCredit.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgPut {
+    return {
+      $type: MsgPut.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      credits: Array.isArray(object?.credits)
+        ? object.credits.map((e: any) => BasketCredit.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: MsgPut): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    if (message.credits) {
+      obj.credits = message.credits.map(e =>
+        e ? BasketCredit.toJSON(e) : undefined,
+      );
+    } else {
+      obj.credits = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgPut>, I>>(object: I): MsgPut {
+    const message = createBaseMsgPut();
+    message.owner = object.owner ?? '';
+    message.basketDenom = object.basketDenom ?? '';
+    message.credits =
+      object.credits?.map(e => BasketCredit.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgPut.$type, MsgPut);
+
+function createBaseMsgPutResponse(): MsgPutResponse {
+  return {
+    $type: 'regen.ecocredit.basket.v1.MsgPutResponse',
+    amountReceived: '',
+  };
+}
+
+export const MsgPutResponse = {
+  $type: 'regen.ecocredit.basket.v1.MsgPutResponse' as const,
+
+  encode(
+    message: MsgPutResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.amountReceived !== '') {
+      writer.uint32(10).string(message.amountReceived);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgPutResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgPutResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.amountReceived = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgPutResponse {
+    return {
+      $type: MsgPutResponse.$type,
+      amountReceived: isSet(object.amountReceived)
+        ? String(object.amountReceived)
+        : '',
+    };
+  },
+
+  toJSON(message: MsgPutResponse): unknown {
+    const obj: any = {};
+    message.amountReceived !== undefined &&
+      (obj.amountReceived = message.amountReceived);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgPutResponse>, I>>(
+    object: I,
+  ): MsgPutResponse {
+    const message = createBaseMsgPutResponse();
+    message.amountReceived = object.amountReceived ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgPutResponse.$type, MsgPutResponse);
+
+function createBaseMsgTake(): MsgTake {
+  return {
+    $type: 'regen.ecocredit.basket.v1.MsgTake',
+    owner: '',
+    basketDenom: '',
+    amount: '',
+    retirementLocation: '',
+    retireOnTake: false,
+  };
+}
+
+export const MsgTake = {
+  $type: 'regen.ecocredit.basket.v1.MsgTake' as const,
+
+  encode(
+    message: MsgTake,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.owner !== '') {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.basketDenom !== '') {
+      writer.uint32(18).string(message.basketDenom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(26).string(message.amount);
+    }
+    if (message.retirementLocation !== '') {
+      writer.uint32(34).string(message.retirementLocation);
+    }
+    if (message.retireOnTake === true) {
+      writer.uint32(40).bool(message.retireOnTake);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgTake {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgTake();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.owner = reader.string();
+          break;
+        case 2:
+          message.basketDenom = reader.string();
+          break;
+        case 3:
+          message.amount = reader.string();
+          break;
+        case 4:
+          message.retirementLocation = reader.string();
+          break;
+        case 5:
+          message.retireOnTake = reader.bool();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgTake {
+    return {
+      $type: MsgTake.$type,
+      owner: isSet(object.owner) ? String(object.owner) : '',
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+      retirementLocation: isSet(object.retirementLocation)
+        ? String(object.retirementLocation)
+        : '',
+      retireOnTake: isSet(object.retireOnTake)
+        ? Boolean(object.retireOnTake)
+        : false,
+    };
+  },
+
+  toJSON(message: MsgTake): unknown {
+    const obj: any = {};
+    message.owner !== undefined && (obj.owner = message.owner);
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    message.retirementLocation !== undefined &&
+      (obj.retirementLocation = message.retirementLocation);
+    message.retireOnTake !== undefined &&
+      (obj.retireOnTake = message.retireOnTake);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgTake>, I>>(object: I): MsgTake {
+    const message = createBaseMsgTake();
+    message.owner = object.owner ?? '';
+    message.basketDenom = object.basketDenom ?? '';
+    message.amount = object.amount ?? '';
+    message.retirementLocation = object.retirementLocation ?? '';
+    message.retireOnTake = object.retireOnTake ?? false;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgTake.$type, MsgTake);
+
+function createBaseMsgTakeResponse(): MsgTakeResponse {
+  return { $type: 'regen.ecocredit.basket.v1.MsgTakeResponse', credits: [] };
+}
+
+export const MsgTakeResponse = {
+  $type: 'regen.ecocredit.basket.v1.MsgTakeResponse' as const,
+
+  encode(
+    message: MsgTakeResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.credits) {
+      BasketCredit.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgTakeResponse {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgTakeResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.credits.push(BasketCredit.decode(reader, reader.uint32()));
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgTakeResponse {
+    return {
+      $type: MsgTakeResponse.$type,
+      credits: Array.isArray(object?.credits)
+        ? object.credits.map((e: any) => BasketCredit.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: MsgTakeResponse): unknown {
+    const obj: any = {};
+    if (message.credits) {
+      obj.credits = message.credits.map(e =>
+        e ? BasketCredit.toJSON(e) : undefined,
+      );
+    } else {
+      obj.credits = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<MsgTakeResponse>, I>>(
+    object: I,
+  ): MsgTakeResponse {
+    const message = createBaseMsgTakeResponse();
+    message.credits =
+      object.credits?.map(e => BasketCredit.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+messageTypeRegistry.set(MsgTakeResponse.$type, MsgTakeResponse);
+
+/** Msg is the regen.ecocredit.basket.v1beta1 Msg service. */
+export interface Msg {
+  /** Create creates a bank denom which wraps credits. */
+  Create(request: DeepPartial<MsgCreate>): Promise<MsgCreateResponse>;
+  /** Put puts credits into a basket in return for basket tokens. */
+  Put(request: DeepPartial<MsgPut>): Promise<MsgPutResponse>;
+  /**
+   * Take takes credits from a basket starting from the oldest
+   * credits first.
+   */
+  Take(request: DeepPartial<MsgTake>): Promise<MsgTakeResponse>;
+}
+
+export class MsgClientImpl implements Msg {
+  private readonly rpc: Rpc;
+  constructor(rpc: Rpc) {
+    this.rpc = rpc;
+    this.Create = this.Create.bind(this);
+    this.Put = this.Put.bind(this);
+    this.Take = this.Take.bind(this);
+  }
+  Create(request: DeepPartial<MsgCreate>): Promise<MsgCreateResponse> {
+    const fromPartial = MsgCreate.fromPartial(request);
+    const data = MsgCreate.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Msg',
+      'Create',
+      data,
+    );
+    return promise.then(data => MsgCreateResponse.decode(new _m0.Reader(data)));
+  }
+
+  Put(request: DeepPartial<MsgPut>): Promise<MsgPutResponse> {
+    const fromPartial = MsgPut.fromPartial(request);
+    const data = MsgPut.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Msg',
+      'Put',
+      data,
+    );
+    return promise.then(data => MsgPutResponse.decode(new _m0.Reader(data)));
+  }
+
+  Take(request: DeepPartial<MsgTake>): Promise<MsgTakeResponse> {
+    const fromPartial = MsgTake.fromPartial(request);
+    const data = MsgTake.encode(fromPartial).finish();
+    const promise = this.rpc.request(
+      'regen.ecocredit.basket.v1.Msg',
+      'Take',
+      data,
+    );
+    return promise.then(data => MsgTakeResponse.decode(new _m0.Reader(data)));
+  }
+}
+
+interface Rpc {
+  request(
+    service: string,
+    method: string,
+    data: Uint8Array,
+  ): Promise<Uint8Array>;
+}
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/api/src/generated/regen/ecocredit/basket/v1/types.ts
+++ b/packages/api/src/generated/regen/ecocredit/basket/v1/types.ts
@@ -1,0 +1,564 @@
+/* eslint-disable */
+import { messageTypeRegistry } from '../../../../typeRegistry';
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { Duration } from '../../../../google/protobuf/duration';
+import { Timestamp } from '../../../../google/protobuf/timestamp';
+
+export const protobufPackage = 'regen.ecocredit.basket.v1';
+
+/** BasketCredit represents the information for a credit batch inside a basket. */
+export interface BasketCredit {
+  $type: 'regen.ecocredit.basket.v1.BasketCredit';
+  /** batch_denom is the unique ID of the credit batch. */
+  batchDenom: string;
+  /**
+   * amount is the number of credits being put into or taken out of the basket.
+   * Decimal values are acceptable within the precision of the corresponding
+   *  credit type for this batch.
+   */
+  amount: string;
+}
+
+/**
+ * DateCriteria represents the information for credit acceptance in a basket.
+ * At most, only one of the values should be set.
+ * NOTE: gogo proto `oneof` is not compatible with Amino signing, hence we directly define
+ * both `start_date_window` and `min_start_date`. In the future, with pulsar, this should change
+ * and we should use `oneof`.
+ */
+export interface DateCriteria {
+  $type: 'regen.ecocredit.basket.v1.DateCriteria';
+  /**
+   * min_start_date (optional) is the earliest start date for batches of credits allowed
+   * into the basket.
+   * At most only one of `start_date_window` and `min_start_date` can be set.
+   */
+  minStartDate?: Date;
+  /**
+   * start_date_window (optional) is a duration of time measured into the past which sets
+   * a cutoff for batch start dates when adding new credits to the basket.
+   * Based on the current block timestamp, credits whose start date is before
+   * `block_timestamp - batch_date_window` will not be allowed into the basket.
+   * At most only one of `start_date_window` and `min_start_date` can be set.
+   */
+  startDateWindow?: Duration;
+}
+
+/** Basket represents a basket in state. */
+export interface Basket {
+  $type: 'regen.ecocredit.basket.v1.Basket';
+  /**
+   * id is the uint64 ID of the basket. It is used internally for reducing
+   * storage space.
+   */
+  id: Long;
+  /** basket_denom is the basket bank denom. */
+  basketDenom: string;
+  /**
+   * name is the unique name of the basket specified in MsgCreate. Basket
+   * names must be unique across all credit types and choices of exponent
+   * above and beyond the uniqueness constraint on basket_denom.
+   */
+  name: string;
+  /** disable_auto_retire indicates whether or not the credits will be retired upon withdraw from the basket. */
+  disableAutoRetire: boolean;
+  /** credit_type_abbrev is the abbreviation of the credit type this basket is able to hold. */
+  creditTypeAbbrev: string;
+  /** date_criteria is the date criteria for batches admitted to the basket. */
+  dateCriteria?: DateCriteria;
+  /** exponent is the exponent for converting credits to/from basket tokens. */
+  exponent: number;
+}
+
+/** BasketBalance stores the amount of credits from a batch in a basket */
+export interface BasketBalance {
+  $type: 'regen.ecocredit.basket.v1.BasketBalance';
+  /** basket_id is the ID of the basket */
+  basketId: Long;
+  /** batch_denom is the denom of the credit batch */
+  batchDenom: string;
+  /** balance is the amount of ecocredits held in the basket */
+  balance: string;
+  /**
+   * batch_start_date is the start date of the batch. This field is used
+   * to create an index which is used to remove the oldest credits first.
+   */
+  batchStartDate?: Date;
+}
+
+function createBaseBasketCredit(): BasketCredit {
+  return {
+    $type: 'regen.ecocredit.basket.v1.BasketCredit',
+    batchDenom: '',
+    amount: '',
+  };
+}
+
+export const BasketCredit = {
+  $type: 'regen.ecocredit.basket.v1.BasketCredit' as const,
+
+  encode(
+    message: BasketCredit,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.batchDenom !== '') {
+      writer.uint32(10).string(message.batchDenom);
+    }
+    if (message.amount !== '') {
+      writer.uint32(18).string(message.amount);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BasketCredit {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBasketCredit();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.batchDenom = reader.string();
+          break;
+        case 2:
+          message.amount = reader.string();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BasketCredit {
+    return {
+      $type: BasketCredit.$type,
+      batchDenom: isSet(object.batchDenom) ? String(object.batchDenom) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
+    };
+  },
+
+  toJSON(message: BasketCredit): unknown {
+    const obj: any = {};
+    message.batchDenom !== undefined && (obj.batchDenom = message.batchDenom);
+    message.amount !== undefined && (obj.amount = message.amount);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BasketCredit>, I>>(
+    object: I,
+  ): BasketCredit {
+    const message = createBaseBasketCredit();
+    message.batchDenom = object.batchDenom ?? '';
+    message.amount = object.amount ?? '';
+    return message;
+  },
+};
+
+messageTypeRegistry.set(BasketCredit.$type, BasketCredit);
+
+function createBaseDateCriteria(): DateCriteria {
+  return {
+    $type: 'regen.ecocredit.basket.v1.DateCriteria',
+    minStartDate: undefined,
+    startDateWindow: undefined,
+  };
+}
+
+export const DateCriteria = {
+  $type: 'regen.ecocredit.basket.v1.DateCriteria' as const,
+
+  encode(
+    message: DateCriteria,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.minStartDate !== undefined) {
+      Timestamp.encode(
+        toTimestamp(message.minStartDate),
+        writer.uint32(10).fork(),
+      ).ldelim();
+    }
+    if (message.startDateWindow !== undefined) {
+      Duration.encode(
+        message.startDateWindow,
+        writer.uint32(18).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DateCriteria {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDateCriteria();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.minStartDate = fromTimestamp(
+            Timestamp.decode(reader, reader.uint32()),
+          );
+          break;
+        case 2:
+          message.startDateWindow = Duration.decode(reader, reader.uint32());
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DateCriteria {
+    return {
+      $type: DateCriteria.$type,
+      minStartDate: isSet(object.minStartDate)
+        ? fromJsonTimestamp(object.minStartDate)
+        : undefined,
+      startDateWindow: isSet(object.startDateWindow)
+        ? Duration.fromJSON(object.startDateWindow)
+        : undefined,
+    };
+  },
+
+  toJSON(message: DateCriteria): unknown {
+    const obj: any = {};
+    message.minStartDate !== undefined &&
+      (obj.minStartDate = message.minStartDate.toISOString());
+    message.startDateWindow !== undefined &&
+      (obj.startDateWindow = message.startDateWindow
+        ? Duration.toJSON(message.startDateWindow)
+        : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DateCriteria>, I>>(
+    object: I,
+  ): DateCriteria {
+    const message = createBaseDateCriteria();
+    message.minStartDate = object.minStartDate ?? undefined;
+    message.startDateWindow =
+      object.startDateWindow !== undefined && object.startDateWindow !== null
+        ? Duration.fromPartial(object.startDateWindow)
+        : undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(DateCriteria.$type, DateCriteria);
+
+function createBaseBasket(): Basket {
+  return {
+    $type: 'regen.ecocredit.basket.v1.Basket',
+    id: Long.UZERO,
+    basketDenom: '',
+    name: '',
+    disableAutoRetire: false,
+    creditTypeAbbrev: '',
+    dateCriteria: undefined,
+    exponent: 0,
+  };
+}
+
+export const Basket = {
+  $type: 'regen.ecocredit.basket.v1.Basket' as const,
+
+  encode(
+    message: Basket,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (!message.id.isZero()) {
+      writer.uint32(8).uint64(message.id);
+    }
+    if (message.basketDenom !== '') {
+      writer.uint32(18).string(message.basketDenom);
+    }
+    if (message.name !== '') {
+      writer.uint32(26).string(message.name);
+    }
+    if (message.disableAutoRetire === true) {
+      writer.uint32(32).bool(message.disableAutoRetire);
+    }
+    if (message.creditTypeAbbrev !== '') {
+      writer.uint32(42).string(message.creditTypeAbbrev);
+    }
+    if (message.dateCriteria !== undefined) {
+      DateCriteria.encode(
+        message.dateCriteria,
+        writer.uint32(50).fork(),
+      ).ldelim();
+    }
+    if (message.exponent !== 0) {
+      writer.uint32(56).uint32(message.exponent);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Basket {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBasket();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.id = reader.uint64() as Long;
+          break;
+        case 2:
+          message.basketDenom = reader.string();
+          break;
+        case 3:
+          message.name = reader.string();
+          break;
+        case 4:
+          message.disableAutoRetire = reader.bool();
+          break;
+        case 5:
+          message.creditTypeAbbrev = reader.string();
+          break;
+        case 6:
+          message.dateCriteria = DateCriteria.decode(reader, reader.uint32());
+          break;
+        case 7:
+          message.exponent = reader.uint32();
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Basket {
+    return {
+      $type: Basket.$type,
+      id: isSet(object.id) ? Long.fromString(object.id) : Long.UZERO,
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
+      name: isSet(object.name) ? String(object.name) : '',
+      disableAutoRetire: isSet(object.disableAutoRetire)
+        ? Boolean(object.disableAutoRetire)
+        : false,
+      creditTypeAbbrev: isSet(object.creditTypeAbbrev)
+        ? String(object.creditTypeAbbrev)
+        : '',
+      dateCriteria: isSet(object.dateCriteria)
+        ? DateCriteria.fromJSON(object.dateCriteria)
+        : undefined,
+      exponent: isSet(object.exponent) ? Number(object.exponent) : 0,
+    };
+  },
+
+  toJSON(message: Basket): unknown {
+    const obj: any = {};
+    message.id !== undefined &&
+      (obj.id = (message.id || Long.UZERO).toString());
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
+    message.name !== undefined && (obj.name = message.name);
+    message.disableAutoRetire !== undefined &&
+      (obj.disableAutoRetire = message.disableAutoRetire);
+    message.creditTypeAbbrev !== undefined &&
+      (obj.creditTypeAbbrev = message.creditTypeAbbrev);
+    message.dateCriteria !== undefined &&
+      (obj.dateCriteria = message.dateCriteria
+        ? DateCriteria.toJSON(message.dateCriteria)
+        : undefined);
+    message.exponent !== undefined &&
+      (obj.exponent = Math.round(message.exponent));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Basket>, I>>(object: I): Basket {
+    const message = createBaseBasket();
+    message.id =
+      object.id !== undefined && object.id !== null
+        ? Long.fromValue(object.id)
+        : Long.UZERO;
+    message.basketDenom = object.basketDenom ?? '';
+    message.name = object.name ?? '';
+    message.disableAutoRetire = object.disableAutoRetire ?? false;
+    message.creditTypeAbbrev = object.creditTypeAbbrev ?? '';
+    message.dateCriteria =
+      object.dateCriteria !== undefined && object.dateCriteria !== null
+        ? DateCriteria.fromPartial(object.dateCriteria)
+        : undefined;
+    message.exponent = object.exponent ?? 0;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(Basket.$type, Basket);
+
+function createBaseBasketBalance(): BasketBalance {
+  return {
+    $type: 'regen.ecocredit.basket.v1.BasketBalance',
+    basketId: Long.UZERO,
+    batchDenom: '',
+    balance: '',
+    batchStartDate: undefined,
+  };
+}
+
+export const BasketBalance = {
+  $type: 'regen.ecocredit.basket.v1.BasketBalance' as const,
+
+  encode(
+    message: BasketBalance,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (!message.basketId.isZero()) {
+      writer.uint32(8).uint64(message.basketId);
+    }
+    if (message.batchDenom !== '') {
+      writer.uint32(18).string(message.batchDenom);
+    }
+    if (message.balance !== '') {
+      writer.uint32(26).string(message.balance);
+    }
+    if (message.batchStartDate !== undefined) {
+      Timestamp.encode(
+        toTimestamp(message.batchStartDate),
+        writer.uint32(34).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): BasketBalance {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseBasketBalance();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.basketId = reader.uint64() as Long;
+          break;
+        case 2:
+          message.batchDenom = reader.string();
+          break;
+        case 3:
+          message.balance = reader.string();
+          break;
+        case 4:
+          message.batchStartDate = fromTimestamp(
+            Timestamp.decode(reader, reader.uint32()),
+          );
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): BasketBalance {
+    return {
+      $type: BasketBalance.$type,
+      basketId: isSet(object.basketId)
+        ? Long.fromString(object.basketId)
+        : Long.UZERO,
+      batchDenom: isSet(object.batchDenom) ? String(object.batchDenom) : '',
+      balance: isSet(object.balance) ? String(object.balance) : '',
+      batchStartDate: isSet(object.batchStartDate)
+        ? fromJsonTimestamp(object.batchStartDate)
+        : undefined,
+    };
+  },
+
+  toJSON(message: BasketBalance): unknown {
+    const obj: any = {};
+    message.basketId !== undefined &&
+      (obj.basketId = (message.basketId || Long.UZERO).toString());
+    message.batchDenom !== undefined && (obj.batchDenom = message.batchDenom);
+    message.balance !== undefined && (obj.balance = message.balance);
+    message.batchStartDate !== undefined &&
+      (obj.batchStartDate = message.batchStartDate.toISOString());
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<BasketBalance>, I>>(
+    object: I,
+  ): BasketBalance {
+    const message = createBaseBasketBalance();
+    message.basketId =
+      object.basketId !== undefined && object.basketId !== null
+        ? Long.fromValue(object.basketId)
+        : Long.UZERO;
+    message.batchDenom = object.batchDenom ?? '';
+    message.balance = object.balance ?? '';
+    message.batchStartDate = object.batchStartDate ?? undefined;
+    return message;
+  },
+};
+
+messageTypeRegistry.set(BasketBalance.$type, BasketBalance);
+
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
+
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in Exclude<keyof T, '$type'>]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
+        Exclude<keyof I, KeysOfUnion<P> | '$type'>,
+        never
+      >;
+
+function toTimestamp(date: Date): Timestamp {
+  const seconds = numberToLong(date.getTime() / 1_000);
+  const nanos = (date.getTime() % 1_000) * 1_000_000;
+  return { $type: 'google.protobuf.Timestamp', seconds, nanos };
+}
+
+function fromTimestamp(t: Timestamp): Date {
+  let millis = t.seconds.toNumber() * 1_000;
+  millis += t.nanos / 1_000_000;
+  return new Date(millis);
+}
+
+function fromJsonTimestamp(o: any): Date {
+  if (o instanceof Date) {
+    return o;
+  } else if (typeof o === 'string') {
+    return new Date(o);
+  } else {
+    return fromTimestamp(Timestamp.fromJSON(o));
+  }
+}
+
+function numberToLong(number: number) {
+  return Long.fromNumber(number);
+}
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/api/src/generated/regen/ecocredit/v1alpha1/events.ts
+++ b/packages/api/src/generated/regen/ecocredit/v1alpha1/events.ts
@@ -43,19 +43,20 @@ export interface EventCreateBatch {
 }
 
 /**
- * EventReceive is an event emitted when credits are received either upon
- * creation of a new batch or upon transfer. Each batch_denom created or
- * transferred will result in a separate EventReceive for easy indexing.
+ * EventReceive is an event emitted when credits are received either via
+ * creation of a new batch, transfer of credits, or taking credits from a
+ * basket. Each batch_denom created, transferred or taken from a basket will
+ * result in a separate EventReceive for easy indexing.
  */
 export interface EventReceive {
   $type: 'regen.ecocredit.v1alpha1.EventReceive';
   /**
    * sender is the sender of the credits in the case that this event is the
    * result of a transfer. It will not be set when credits are received at
-   * initial issuance.
+   * initial issuance or taken from a basket.
    */
   sender: string;
-  /** recipient is the recipient of the credits */
+  /** recipient is the recipient of the credits. */
   recipient: string;
   /** batch_denom is the unique ID of credit batch. */
   batchDenom: string;
@@ -63,6 +64,13 @@ export interface EventReceive {
   tradableAmount: string;
   /** retired_amount is the decimal number of retired credits received. */
   retiredAmount: string;
+  /**
+   * basket_denom is the denom of the basket. when the basket_denom field is
+   * set, it indicates that this event was triggered by the transfer of credits
+   * from a basket. It will not be set if the credits were sent by a user, or by
+   * initial issuance.
+   */
+  basketDenom: string;
 }
 
 /**
@@ -316,6 +324,7 @@ function createBaseEventReceive(): EventReceive {
     batchDenom: '',
     tradableAmount: '',
     retiredAmount: '',
+    basketDenom: '',
   };
 }
 
@@ -340,6 +349,9 @@ export const EventReceive = {
     }
     if (message.retiredAmount !== '') {
       writer.uint32(42).string(message.retiredAmount);
+    }
+    if (message.basketDenom !== '') {
+      writer.uint32(50).string(message.basketDenom);
     }
     return writer;
   },
@@ -366,6 +378,9 @@ export const EventReceive = {
         case 5:
           message.retiredAmount = reader.string();
           break;
+        case 6:
+          message.basketDenom = reader.string();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -386,6 +401,7 @@ export const EventReceive = {
       retiredAmount: isSet(object.retiredAmount)
         ? String(object.retiredAmount)
         : '',
+      basketDenom: isSet(object.basketDenom) ? String(object.basketDenom) : '',
     };
   },
 
@@ -398,6 +414,8 @@ export const EventReceive = {
       (obj.tradableAmount = message.tradableAmount);
     message.retiredAmount !== undefined &&
       (obj.retiredAmount = message.retiredAmount);
+    message.basketDenom !== undefined &&
+      (obj.basketDenom = message.basketDenom);
     return obj;
   },
 
@@ -410,6 +428,7 @@ export const EventReceive = {
     message.batchDenom = object.batchDenom ?? '';
     message.tradableAmount = object.tradableAmount ?? '';
     message.retiredAmount = object.retiredAmount ?? '';
+    message.basketDenom = object.basketDenom ?? '';
     return message;
   },
 };

--- a/packages/api/src/generated/regen/ecocredit/v1alpha1/types.ts
+++ b/packages/api/src/generated/regen/ecocredit/v1alpha1/types.ts
@@ -18,7 +18,10 @@ export interface ClassInfo {
   issuers: string[];
   /** metadata is any arbitrary metadata to attached to the credit class. */
   metadata: Uint8Array;
-  /** credit_type describes the type of credit (e.g. carbon, biodiversity), as well as unit and precision. */
+  /**
+   * credit_type describes the type of credit (e.g. carbon, biodiversity), as
+   * well as unit and precision.
+   */
   creditType?: CreditType;
   /** The number of batches issued in this credit class. */
   numBatches: Long;
@@ -87,6 +90,8 @@ export interface Params {
   allowlistEnabled: boolean;
   /** credit_types is a list of definitions for credit types */
   creditTypes: CreditType[];
+  /** basket_creation_fee is the fee to create a new basket denom. */
+  basketCreationFee: Coin[];
 }
 
 /**
@@ -434,6 +439,7 @@ function createBaseParams(): Params {
     allowedClassCreators: [],
     allowlistEnabled: false,
     creditTypes: [],
+    basketCreationFee: [],
   };
 }
 
@@ -455,6 +461,9 @@ export const Params = {
     }
     for (const v of message.creditTypes) {
       CreditType.encode(v!, writer.uint32(34).fork()).ldelim();
+    }
+    for (const v of message.basketCreationFee) {
+      Coin.encode(v!, writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
@@ -478,6 +487,9 @@ export const Params = {
         case 4:
           message.creditTypes.push(CreditType.decode(reader, reader.uint32()));
           break;
+        case 5:
+          message.basketCreationFee.push(Coin.decode(reader, reader.uint32()));
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -500,6 +512,9 @@ export const Params = {
         : false,
       creditTypes: Array.isArray(object?.creditTypes)
         ? object.creditTypes.map((e: any) => CreditType.fromJSON(e))
+        : [],
+      basketCreationFee: Array.isArray(object?.basketCreationFee)
+        ? object.basketCreationFee.map((e: any) => Coin.fromJSON(e))
         : [],
     };
   },
@@ -527,6 +542,13 @@ export const Params = {
     } else {
       obj.creditTypes = [];
     }
+    if (message.basketCreationFee) {
+      obj.basketCreationFee = message.basketCreationFee.map(e =>
+        e ? Coin.toJSON(e) : undefined,
+      );
+    } else {
+      obj.basketCreationFee = [];
+    }
     return obj;
   },
 
@@ -539,6 +561,8 @@ export const Params = {
     message.allowlistEnabled = object.allowlistEnabled ?? false;
     message.creditTypes =
       object.creditTypes?.map(e => CreditType.fromPartial(e)) || [];
+    message.basketCreationFee =
+      object.basketCreationFee?.map(e => Coin.fromPartial(e)) || [];
     return message;
   },
 };


### PR DESCRIPTION
Closes: #31

In particular, adds basket v1 proto and update other regen proto files.
Will tag v0.2.1 once that's merged and publish it to npm.

**Note for reviewers:** No need to review the full files diff, just check that we've got everything from https://github.com/regen-network/regen-ledger/tree/5fb6268ed18a488ab88fb3bfa4b84e10892a7562/proto/regen/ecocredit/basket/v1 and corresponding types generated in `packages/api/src/generated/regen`
