### PR TITLE
Update regen-js ts config to not build api as an ES6 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.2](https://github.com/regen-network/regen-js/compare/v0.2.1...v0.2.2) (2022-03-14)
+
+
+### Changed
+
+* **api:** Update tsconfig to not build @regen-network/api as an ES6 module.
+
+
+
+
+
+
 ## [0.2.1](https://github.com/regen-network/regen-js/compare/v0.2.0...v0.2.1) (2022-03-08)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
 	"packages": [
 		"packages/*"
 	],
-	"version": "0.2.1"
+	"version": "0.2.2"
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.2](https://github.com/regen-network/regen-js/compare/v0.2.1...v0.2.2) (2022-03-14)
+
+
+### Changed
+
+* **api:** Update tsconfig to not build @regen-network/api as an ES6 module.
+
+
+
+
+
+
+
 ## [0.2.1](https://github.com/regen-network/regen-js/compare/v0.2.0...v0.2.1) (2022-03-08)
 
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@regen-network/api",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"author": "admin@regen.network",
 	"description": "A client library for the Regen Ledger",
 	"license": "Apache-2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
 		"@cosmjs/stargate": "^0.27.0"
 	},
 	"scripts": {
-		"build": "rimraf lib && tsc --downlevelIteration",
+		"build": "rimraf lib && tsc",
 		"gen": "rimraf src/generated && mkdir src/generated && ./scripts/protocgen.sh",
 		"test": "jest"
 	},

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -2,8 +2,7 @@
 	"compilerOptions": {
 		"declaration": true,
 		"esModuleInterop": true,
-		"outDir": "lib",
-		"downlevelIteration": true
+		"outDir": "lib"
 	},
 	"extends": "../../tsconfig",
 	"include": ["src"]

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,8 +1,9 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"esModuleInterop": true, // Somehow protobuf.js doesn't work when this is set to true.
-		"outDir": "lib"
+		"esModuleInterop": true,
+		"outDir": "lib",
+		"downlevelIteration": true
 	},
 	"extends": "../../tsconfig",
 	"include": ["src"]

--- a/packages/demo-app/CHANGELOG.md
+++ b/packages/demo-app/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.2](https://github.com/regen-network/regen-js/compare/v0.2.1...v0.2.2) (2022-03-14)
+
+**Note:** Version bump only for package @regen-network/demo-app
+
+
+
+
+
+
+
 ## [0.2.1](https://github.com/regen-network/regen-js/compare/v0.2.0...v0.2.1) (2022-03-08)
 
 **Note:** Version bump only for package @regen-network/demo-app

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "@regen-network/demo-app",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"author": "admin@regen.network",
 	"description": "Demo web application using @regen-network/api",
 	"license": "Apache-2.0",
 	"private": true,
 	"repository": "https://github.com/regen-network/regen-js",
 	"dependencies": {
-		"@regen-network/api": "^0.2.1",
+		"@regen-network/api": "^0.2.2",
 		"@testing-library/jest-dom": "^5.11.8",
 		"@testing-library/react": "^11.2.2",
 		"@testing-library/user-event": "^12.6.0",

--- a/packages/demo-app/tsconfig.json
+++ b/packages/demo-app/tsconfig.json
@@ -16,6 +16,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "target": "es6",
+    "sourceMap": true,
   },
   "extends": "../../tsconfig",
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,8 @@
 		"noUnusedParameters": false,
 		"pretty": true,
 		"removeComments": false,
-		"sourceMap": true,
 		"skipLibCheck": true,
 		"strict": true,
-		"target": "es6",
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"exclude": ["**/lib/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
 		"removeComments": false,
 		"skipLibCheck": true,
 		"strict": true,
+		"downlevelIteration": true,
 		"typeRoots": ["./node_modules/@types"]
 	},
 	"exclude": ["**/lib/**/*"],


### PR DESCRIPTION
closes: #33 