### PR TITLE
feat: update ecocredit amino types

### DIFF
--- a/packages/api/src/tx/modules/ecocredit/v1/bridge_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/bridge_amino.ts
@@ -4,7 +4,7 @@ import { MsgBridge } from '../../../../generated/regen/ecocredit/v1/tx';
 import { Credits } from '../../../../generated/regen/ecocredit/v1/types';
 import { AminoCredits } from './msg_cancel';
 
-const msgBridgeAminoType = 'regen.core/MsgBridge';
+const msgBridgeAminoType = 'regen/MsgBridge';
 
 export const bridgeTypeUrl = '/' + MsgBridge.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/create_batch_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/create_batch_amino.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../generated/regen/ecocredit/v1/types';
 import { AminoDate } from '../converter-utils';
 
-const msgCreateBatchAminoType = 'regen.core/MsgCreateBatch';
+const msgCreateBatchAminoType = 'regen/MsgCreateBatch';
 
 export const createBatchTypeUrl = '/' + MsgCreateBatch.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/create_class_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/create_class_amino.ts
@@ -3,7 +3,7 @@ import { AminoConverter } from '@cosmjs/stargate';
 import { MsgCreateClass } from '../../../../generated/regen/ecocredit/v1/tx';
 import { Coin } from '../../../../generated/cosmos/base/v1beta1/coin';
 
-const msgCreateClassAminoType = 'regen.core/MsgCreateClass';
+const msgCreateClassAminoType = 'regen/MsgCreateClass';
 
 export const createClassTypeUrl = '/' + MsgCreateClass.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/create_project_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/create_project_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgCreateProject } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgCreateProjectAminoType = 'regen.core/MsgCreateProject';
+const msgCreateProjectAminoType = 'regen/MsgCreateProject';
 
 export const createProjectTypeUrl = '/' + MsgCreateProject.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/mint_batch_credits_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/mint_batch_credits_amino.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../generated/regen/ecocredit/v1/types';
 import { AminoBatchIssuance, AminoOriginTx } from './create_batch_amino';
 
-const msgMintBatchCreditsAminoType = 'regen.core/MsgMintBatchCredits';
+const msgMintBatchCreditsAminoType = 'regen/MsgMintBatchCredits';
 
 export const mintBatchCreditsTypeUrl = '/' + MsgMintBatchCredits.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/msg_cancel.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/msg_cancel.ts
@@ -3,7 +3,7 @@ import { AminoConverter } from '@cosmjs/stargate';
 import { MsgCancel } from '../../../../generated/regen/ecocredit/v1/tx';
 import { Credits } from '../../../../generated/regen/ecocredit/v1/types';
 
-const msgCancelAminoType = 'regen.core/MsgCancel';
+const msgCancelAminoType = 'regen/MsgCancel';
 
 export const cancelTypeUrl = '/' + MsgCancel.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/retire_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/retire_amino.ts
@@ -4,7 +4,7 @@ import { MsgRetire } from '../../../../generated/regen/ecocredit/v1/tx';
 import { Credits } from '../../../../generated/regen/ecocredit/v1/types';
 import { AminoCredits } from './msg_cancel';
 
-const msgRetireAminoType = 'regen.core/MsgRetire';
+const msgRetireAminoType = 'regen/MsgRetire';
 
 export const retireTypeUrl = '/' + MsgRetire.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/seal_batch_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/seal_batch_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgSealBatch } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgSealBatchAminoType = 'regen.core/MsgSealBatch';
+const msgSealBatchAminoType = 'regen/MsgSealBatch';
 
 export const sealBatchTypeUrl = '/' + MsgSealBatch.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/send_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/send_amino.ts
@@ -5,7 +5,7 @@ import {
   MsgSend_SendCredits,
 } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgSendAminoType = 'regen.core/MsgSend';
+const msgSendAminoType = 'regen/MsgSend';
 
 export const sendTypeUrl = '/' + MsgSend.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/update_class_admin_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/update_class_admin_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgUpdateClassAdmin } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgUpdateClassAdminAminoType = 'regen.core/MsgUpdateClassAdmin';
+const msgUpdateClassAdminAminoType = 'regen/MsgUpdateClassAdmin';
 
 export const updateClassAdminTypeUrl = '/' + MsgUpdateClassAdmin.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/update_class_issuers_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/update_class_issuers_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgUpdateClassIssuers } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgUpdateClassIssuersAminoType = 'regen.core/MsgUpdateClassIssuers';
+const msgUpdateClassIssuersAminoType = 'regen/MsgUpdateClassIssuers';
 
 export const updateClassIssuersTypeUrl = '/' + MsgUpdateClassIssuers.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/update_class_metadata_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/update_class_metadata_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgUpdateClassMetadata } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgUpdateClassMetadataAminoType = 'regen.core/MsgUpdateClassMetadata';
+const msgUpdateClassMetadataAminoType = 'regen/MsgUpdateClassMetadata';
 
 export const updateClassMetadataTypeUrl = '/' + MsgUpdateClassMetadata.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/update_project_admin_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/update_project_admin_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgUpdateProjectAdmin } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgUpdateProjectAdminAminoType = 'regen.core/MsgUpdateProjectAdmin';
+const msgUpdateProjectAdminAminoType = 'regen/MsgUpdateProjectAdmin';
 
 export const updateProjectAdminTypeUrl = '/' + MsgUpdateProjectAdmin.$type;
 

--- a/packages/api/src/tx/modules/ecocredit/v1/update_project_metadata_amino.ts
+++ b/packages/api/src/tx/modules/ecocredit/v1/update_project_metadata_amino.ts
@@ -2,7 +2,7 @@ import { AminoMsg } from '@cosmjs/amino';
 import { AminoConverter } from '@cosmjs/stargate';
 import { MsgUpdateProjectMetadata } from '../../../../generated/regen/ecocredit/v1/tx';
 
-const msgUpdateProjectMetadataAminoType = 'regen.core/MsgUpdateProjectMetadata';
+const msgUpdateProjectMetadataAminoType = 'regen/MsgUpdateProjectMetadata';
 
 export const updateProjectMetadataTypeUrl =
   '/' + MsgUpdateProjectMetadata.$type;


### PR DESCRIPTION
closes: regen-network/regen-js#62

- update ecocredit amino types from `regen.core/<message>` to `regen/<message>`