### PR TITLE
build: move @osmonauts/lcd to dependencies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,6 +39,7 @@
     "@cosmjs/proto-signing": "0.29.4",
     "@cosmjs/stargate": "0.29.4",
     "@cosmjs/tendermint-rpc": "^0.29.4",
+    "@osmonauts/lcd": "^0.11.1",
     "protobufjs": "^6.11.2"
   },
   "devDependencies": {
@@ -54,7 +55,6 @@
     "@babel/plugin-transform-runtime": "7.19.1",
     "@babel/preset-env": "7.19.4",
     "@babel/preset-typescript": "^7.18.6",
-    "@osmonauts/lcd": "^0.11.1",
     "@osmonauts/telescope": "^0.78.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "29.1.2",


### PR DESCRIPTION
Attempting to run groups-ui with `api` package locally based on `main` branch was producing the following error:

```
✘ [ERROR] Could not resolve "@osmonauts/lcd"

    node_modules/@regen-network/api/module/codegen/cosmos/lcd.js:1:26:
      1 │ import { LCDClient } from "@osmonauts/lcd";
        ╵                           ~~~~~~~~~~~~~~~~
```

Moving `@osmonauts/lcd` from dev dependencies to dependencies resolves the issue.