### PR TITLE
chore: api v1.0.0-alpha5 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@
 
 This API is still under heavy construction, be ready for unexpected breaking changes.
 
-### v1.0.0-alpha4
-
-The `v1.0.0-alpha4` release tag includes a manual override of some generated code in `src` in order to resolve a downstream issue within [regen-network/groups-ui](https://github.com/regen-network/groups-ui). For more information, see [#79](https://github.com/regen-network/regen-js/pull/79) and [regen-network/groups-ui#69](https://github.com/regen-network/groups-ui/pull/69).
-
 ## Get Started
 
 ### Install and build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "regen-js",
-	"version": "1.0.0-alpha4",
+	"version": "1.0.0-alpha5",
 	"author": "admin@regen.network",
 	"description": "Regen Network does JavaScript",
 	"license": "Apache-2.0",

--- a/packages/api-demo/package.json
+++ b/packages/api-demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@regen-network/api-demo",
-	"version": "v1.0.0-alpha4",
+	"version": "v1.0.0-alpha5",
 	"author": "admin@regen.network",
 	"description": "Demo application using @regen-network/api",
 	"license": "Apache-2.0",
@@ -8,7 +8,7 @@
 	"repository": "https://github.com/regen-network/regen-js",
 	"dependencies": {
 		"@keplr-wallet/types": "^0.12.15",
-		"@regen-network/api": "^1.0.0-alpha4",
+		"@regen-network/api": "^1.0.0-alpha5",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^14.0.0",
 		"@testing-library/user-event": "^14.4.3",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,5 +1,12 @@
 # @regen-network/api
 
+
+## 🚧 Warning
+
+This API is still under heavy construction, be ready for unexpected breaking changes.
+
+The `v1.0.0-alpha4` and `v1.0.0-alpha5` release tags include manual overrides of generated code in `src` in order to resolve a downstream issue within [regen-network/groups-ui](https://github.com/regen-network/groups-ui). For more information, see [#84](https://github.com/regen-network/regen-js/pull/84).
+
 ## Table of Contents
 
 - [Install](#install)
@@ -17,7 +24,7 @@
 ## Install
 
 ```sh
-yarn add @regen-network/api@v1.0.0-alpha4
+yarn add @regen-network/api@v1.0.0-alpha5
 ```
 
 ## Usage

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@regen-network/api",
-  "version": "v1.0.0-alpha4",
+  "version": "v1.0.0-alpha5",
   "author": "admin@regen.network",
   "description": "Javascript API for Regen Ledger",
   "license": "Apache-2.0",


### PR DESCRIPTION
This pull request preps the next alpha release of the `api` package (`v1.0.0-alpha5`).